### PR TITLE
Update 98-copy-issue-by-number.yml - 

### DIFF
--- a/.github/workflows/98-copy-issue-by-number.yml
+++ b/.github/workflows/98-copy-issue-by-number.yml
@@ -9,7 +9,6 @@ name: 98 - Copy specific issue from starter repo (creates new issue)
 env:
     GH_TOKEN: ${{ github.token }}
     STARTER: https://github.com/ucsb-cs156/proj-gauchoride
-    TAG: ${{vars.QXX}}
     
 on:
   workflow_dispatch:
@@ -31,7 +30,7 @@ jobs:
         id: get-issues
         run: |
           number=${{ github.event.inputs.issue_number }}
-          GH_REPO=${{env.STARTER}} gh issue list -s open -l M23 --json number,title,body,labels | jq --argjson issue_num $number  '[ ( .[] | select(.number==$issue_num) | { number: .number, title: .title , body: .body, labels: ( .labels | [ .[].name ] | join(",") )  } ) ]' > issues.json
+          GH_REPO=${{env.STARTER}} gh issue list -s open  --json number,title,body,labels | jq --argjson issue_num $number  '[ ( .[] | select(.number==$issue_num) | { number: .number, title: .title , body: .body, labels: ( .labels | [ .[].name ] | join(",") )  } ) ]' > issues.json
           cat issues.json
           {
                echo 'issues<<THIS_IS_THIS_EOF_MARKER'


### PR DESCRIPTION
In this PR, we remove the hardcoded M23 as well as all code related to filtering issues by tag/label.

The reason is that when we are selecting a specific issue by number, there is no reason to do any other filtering.