### PR TITLE
Fixed "Apply to be rider" should not be visible to non-user

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -34,6 +34,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
     }
   }
 
+
   return (
     <>
       {
@@ -125,7 +126,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                !hasRole(currentUser, "ROLE_RIDER") && (hasRole(currentUser, "ROLE_MEMBER") || hasRole(currentUser, "ROLE_ADMIN")) && (
+                currentUser.loggedIn == true && !hasRole(currentUser, "ROLE_RIDER") && (
                   <Nav.Link id ="appnavbar-applytobearider-link" data-testid="appnavbar-applytoberider" as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -125,7 +125,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                !hasRole(currentUser, "ROLE_RIDER") && isParticipant(currentUser) && (
+                !hasRole(currentUser, "ROLE_RIDER") && (hasRole(currentUser, "ROLE_MEMBER") || hasRole(currentUser, "ROLE_ADMIN")) && (
                   <Nav.Link id ="appnavbar-applytobearider-link" data-testid="appnavbar-applytoberider" as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -126,7 +126,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                currentUser.loggedIn == true && !hasRole(currentUser, "ROLE_RIDER") && (
+                currentUser.loggedIn === true && !hasRole(currentUser, "ROLE_RIDER") && (
                   <Nav.Link id ="appnavbar-applytobearider-link" data-testid="appnavbar-applytoberider" as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -125,7 +125,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                !hasRole(currentUser, "ROLE_RIDER") && (
+                !hasRole(currentUser, "ROLE_RIDER") && isParticipant(currentUser) && (
                   <Nav.Link id ="appnavbar-applytobearider-link" data-testid="appnavbar-applytoberider" as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }


### PR DESCRIPTION
Now, only users who are not riders already have access to the "Apply To Be Rider" navbar button

<img width="1371" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/fea8a397-d4a9-4918-a133-d31ad616f48a">

<img width="1298" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/bdb8df28-1319-4f1d-a8e1-83c1aefabb68">



Closes #5 