### PR TITLE
Change the driver id into dropdowns in shift form

### DIFF
--- a/frontend/src/main/components/Shift/ShiftForm.js
+++ b/frontend/src/main/components/Shift/ShiftForm.js
@@ -115,7 +115,6 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                 </Form.Control.Feedback>
             </Form.Group>
 
-            {drivers &&
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="driverID">Driver ID</Form.Label>
                 <Form.Control
@@ -124,23 +123,16 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     name="driverID"
                     as="select"
                     type="select"
-                    isInvalid={Boolean(errors.driverID)}
-                    {...register("driverID", {
-                        required: "Driver ID is required."
-                    })}
+                    {...register("driverID")}
                 >
                     {drivers && drivers.map(driver => (
-                        <option key={driver.id} value={driver.id}>
+                        <option key={driver.id} data-testid={testIdPrefix + "-driverID-" + driver.id} value={driver.id}>
                             {driver.id + " - " + driver.fullName}
                         </option>
                     ))}
                 </Form.Control>
-                <Form.Control.Feedback type="invalid">
-                    {errors.driverID?.message}
-                </Form.Control.Feedback>
-            </Form.Group>}
+            </Form.Group>
 
-            {drivers &&
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="driverBackupID">Driver Backup ID</Form.Label>
                 <Form.Control
@@ -149,21 +141,15 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     name="driverBackupID"
                     as="select"
                     type="select"
-                    isInvalid={Boolean(errors.driverBackupID)}
-                    {...register("driverBackupID", {
-                        required: "Driver Backup ID is required."
-                    })}
+                    {...register("driverBackupID")}
                 >
                     {drivers && drivers.map(driver => (
-                        <option key={driver.id} value={driver.id}>
+                        <option key={driver.id} data-testid={testIdPrefix + "-driverBackupID-" + driver.id} value={driver.id}>
                             {driver.id + " - " + driver.fullName}
                         </option>
                     ))}
                 </Form.Control>
-                <Form.Control.Feedback type="invalid">
-                    {errors.driverBackupID?.message}
-                </Form.Control.Feedback>
-            </Form.Group>}
+            </Form.Group>
 
             <Button
                 type="submit"

--- a/frontend/src/main/components/Shift/ShiftForm.js
+++ b/frontend/src/main/components/Shift/ShiftForm.js
@@ -1,8 +1,22 @@
 import { Button, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
+import { useBackend } from 'main/utils/useBackend';
 
 function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+
+    const { data: drivers, _error, _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/drivers/all`],
+            {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+                method: "GET",
+                url: `/api/drivers/all`
+                // Stryker restore all
+            },
+        );
+
+
     // Stryker disable all
     const {
         register,
@@ -101,39 +115,55 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                 </Form.Control.Feedback>
             </Form.Group>
 
+            {drivers &&
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="driverID">Driver ID</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-driverID"}
                     id="driverID"
                     name="driverID"
-                    type="number"
+                    as="select"
+                    type="select"
                     isInvalid={Boolean(errors.driverID)}
                     {...register("driverID", {
                         required: "Driver ID is required."
                     })}
-                />
+                >
+                    {drivers && drivers.map(driver => (
+                        <option key={driver.id} value={driver.id}>
+                            {driver.id + " - " + driver.fullName}
+                        </option>
+                    ))}
+                </Form.Control>
                 <Form.Control.Feedback type="invalid">
                     {errors.driverID?.message}
                 </Form.Control.Feedback>
-            </Form.Group>
+            </Form.Group>}
 
+            {drivers &&
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="driverBackupID">Driver Backup ID</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-driverBackupID"}
                     id="driverBackupID"
                     name="driverBackupID"
-                    type="number"
+                    as="select"
+                    type="select"
                     isInvalid={Boolean(errors.driverBackupID)}
                     {...register("driverBackupID", {
                         required: "Driver Backup ID is required."
                     })}
-                />
+                >
+                    {drivers && drivers.map(driver => (
+                        <option key={driver.id} value={driver.id}>
+                            {driver.id + " - " + driver.fullName}
+                        </option>
+                    ))}
+                </Form.Control>
                 <Form.Control.Feedback type="invalid">
                     {errors.driverBackupID?.message}
                 </Form.Control.Feedback>
-            </Form.Group>
+            </Form.Group>}
 
             <Button
                 type="submit"

--- a/frontend/src/tests/components/Shift/ShiftForm.test.js
+++ b/frontend/src/tests/components/Shift/ShiftForm.test.js
@@ -47,11 +47,11 @@ describe("ShiftForm tests", () => {
             expect(header).toBeInTheDocument();
         });
 
-        var { getByText } = within(screen.getByTestId("ShiftForm-driverID-1"));
-        expect(getByText("1 - undefined")).toBeInTheDocument();
+        const { getByText : getByText1 } = within(screen.getByTestId("ShiftForm-driverID-1"));
+        expect(getByText1("1 - undefined")).toBeInTheDocument();
 
-        var { getByText } = within(screen.getByTestId("ShiftForm-driverBackupID-1"));
-        expect(getByText("1 - undefined")).toBeInTheDocument();
+        const { getByText :getByText2 } = within(screen.getByTestId("ShiftForm-driverBackupID-1"));
+        expect(getByText2("1 - undefined")).toBeInTheDocument();
 
     });
 

--- a/frontend/src/tests/pages/Shift/ShiftCreatePage.test.js
+++ b/frontend/src/tests/pages/Shift/ShiftCreatePage.test.js
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import driverFixtures from "fixtures/driverFixtures";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
@@ -38,6 +39,7 @@ describe("ShiftCreatePage tests", () => {
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     });
 
@@ -82,7 +84,7 @@ describe("ShiftCreatePage tests", () => {
         )
 
         await waitFor(() => {
-            expect(screen.getByLabelText("Day of the Week")).toBeInTheDocument();
+            expect(screen.getByLabelText("Driver ID")).toBeInTheDocument();
         });
 
         // Test for Day input

--- a/frontend/src/tests/pages/Shift/ShiftEditPage.test.js
+++ b/frontend/src/tests/pages/Shift/ShiftEditPage.test.js
@@ -1,4 +1,5 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { within } from '@testing-library/dom'
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import ShiftEditPage from "main/pages/Shift/ShiftEditPage";
@@ -9,6 +10,7 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 import mockConsole from "jest-mock-console";
+import driverFixtures from "fixtures/driverFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -45,6 +47,7 @@ describe("ShiftEditPage tests", () => {
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
             axiosMock.onGet("/api/shift", { params: { id: 17 } }).timeout();
+            axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
         });
 
         const queryClient = new QueryClient();
@@ -74,6 +77,7 @@ describe("ShiftEditPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
             axiosMock.onGet("/api/shift", { params: { id: 17 } }).reply(200, {
                 id: 17,
                 day: "Tuesday",
@@ -114,7 +118,7 @@ describe("ShiftEditPage tests", () => {
                 </QueryClientProvider>
             );
 
-            await findByTestId("ShiftForm-day");
+            await waitFor(() => findByTestId("ShiftForm-driverID"));
 
             const dayField = getByTestId("ShiftForm-day");
             const startField = getByTestId("ShiftForm-shiftStart");
@@ -125,8 +129,14 @@ describe("ShiftEditPage tests", () => {
             expect(dayField).toHaveValue("Tuesday");
             expect(startField).toHaveValue("05:00PM");
             expect(endField).toHaveValue("07:30PM");
-            expect(driverField).toHaveValue(1);
-            expect(backupDriverField).toHaveValue(2);
+            expect(driverField).toHaveValue("1");
+            expect(backupDriverField).toHaveValue("2");
+
+            var { getByText } = within(screen.getByTestId("ShiftForm-driverID-1"));
+            expect(getByText("1 - undefined")).toBeInTheDocument();
+
+            var { getByText } = within(screen.getByTestId("ShiftForm-driverBackupID-1"));
+            expect(getByText("1 - undefined")).toBeInTheDocument();
         });
 
         test("Changes when you click Update", async () => {
@@ -139,7 +149,7 @@ describe("ShiftEditPage tests", () => {
                 </QueryClientProvider>
             );
         
-            await findByTestId("ShiftForm-day");
+            await waitFor(() => findByTestId("ShiftForm-driverID"));
         
             const dayField = getByTestId("ShiftForm-day");
             const startField = getByTestId("ShiftForm-shiftStart");
@@ -152,16 +162,16 @@ describe("ShiftEditPage tests", () => {
             expect(dayField).toHaveValue("Tuesday");
             expect(startField).toHaveValue("05:00PM");
             expect(endField).toHaveValue("07:30PM");
-            expect(driverField).toHaveValue(1);
-            expect(backupDriverField).toHaveValue(2);
+            expect(driverField).toHaveValue("1");
+            expect(backupDriverField).toHaveValue("2");
 
             expect(submitButton).toBeInTheDocument();
         
             fireEvent.change(dayField, { target: { value: 'Monday' } });
             fireEvent.change(startField, { target: { value: '03:30PM' } });
             fireEvent.change(endField, { target: { value: "04:30PM" } });
-            fireEvent.change(driverField, { target: { value: 2 } });
-            fireEvent.change(backupDriverField, { target: { value: 3 } });
+            fireEvent.change(driverField, { target: { value: "2" } });
+            fireEvent.change(backupDriverField, { target: { value: "3" } });
         
             fireEvent.click(submitButton);
 

--- a/frontend/src/tests/pages/Shift/ShiftEditPage.test.js
+++ b/frontend/src/tests/pages/Shift/ShiftEditPage.test.js
@@ -132,11 +132,11 @@ describe("ShiftEditPage tests", () => {
             expect(driverField).toHaveValue("1");
             expect(backupDriverField).toHaveValue("2");
 
-            var { getByText } = within(screen.getByTestId("ShiftForm-driverID-1"));
-            expect(getByText("1 - undefined")).toBeInTheDocument();
+            const { getByText : getByText1 } = within(screen.getByTestId("ShiftForm-driverID-1"));
+            expect(getByText1("1 - undefined")).toBeInTheDocument();
 
-            var { getByText } = within(screen.getByTestId("ShiftForm-driverBackupID-1"));
-            expect(getByText("1 - undefined")).toBeInTheDocument();
+            const { getByText : getByText2 } = within(screen.getByTestId("ShiftForm-driverBackupID-1"));
+            expect(getByText2("1 - undefined")).toBeInTheDocument();
         });
 
         test("Changes when you click Update", async () => {

--- a/frontend/src/tests/pages/Shift/ShiftEditPage.test.js
+++ b/frontend/src/tests/pages/Shift/ShiftEditPage.test.js
@@ -135,7 +135,7 @@ describe("ShiftEditPage tests", () => {
             const { getByText : getByText1 } = within(screen.getByTestId("ShiftForm-driverID-1"));
             expect(getByText1("1 - undefined")).toBeInTheDocument();
 
-            const { getByText : getByText2 } = within(screen.getByTestId("ShiftForm-driverBackupID-1"));
+            const { getByText :getByText2 } = within(screen.getByTestId("ShiftForm-driverBackupID-1"));
             expect(getByText2("1 - undefined")).toBeInTheDocument();
         });
 


### PR DESCRIPTION
- As an Admin
- I can select a driver from a dropdown
- So that I dont have to memorize driver ids

<img width="392" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/cd443980-b6e8-45ff-b26c-98f75fb0b983">

Was very inconvenient since admin needs to remember the driver ids and put them in as text manually.

Now admin would be able to select a driver from the dropdown, with their names displayed. No longer have to remember driver ids.

added useBackend in shiftForm, changed shiftForm, shiftEditPage, shiftCreatePage tests to pass stryker and coverage

Closes #14 