### PR TITLE
Improve Readability of Shift Table Headers

### DIFF
--- a/frontend/src/main/components/Shift/ShiftTable.js
+++ b/frontend/src/main/components/Shift/ShiftTable.js
@@ -29,7 +29,7 @@ export default function ShiftTable({
         { onSuccess: onDeleteSuccess },
         ["/api/shift/all"]
     );
-    // Stryker restore all 
+    // Stryker restore all
 
     // Stryker disable next-line all : TODO try to make a good test for this
     const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
@@ -44,11 +44,11 @@ export default function ShiftTable({
             accessor: 'day',
         },
         {
-            Header: 'Shift start',
+            Header: 'Shift Start',
             accessor: 'shiftStart',
         },
         {
-            Header: 'Shift end',
+            Header: 'Shift End',
             accessor: 'shiftEnd',
         },
         {
@@ -60,7 +60,7 @@ export default function ShiftTable({
               ),
         },
         {
-            Header: 'Backup driver',
+            Header: 'Backup Driver',
             accessor: 'driverBackupID',
             Cell: ({ value }) => (
                 // Stryker disable next-line all : hard to set up test
@@ -73,7 +73,7 @@ export default function ShiftTable({
         columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
         columns.push(ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix));
     }
-    
+
     if (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_DRIVER")) {
         columns.push(ButtonColumn("Info", "success", infoCallback, testIdPrefix))
     }
@@ -84,4 +84,3 @@ export default function ShiftTable({
         testid={testIdPrefix}
     />;
 };
-

--- a/frontend/src/tests/components/Shift/ShiftTable.test.js
+++ b/frontend/src/tests/components/Shift/ShiftTable.test.js
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { BrowserRouter as Router } from 'react-router-dom';
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
-  
+
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useNavigate: () => mockedNavigate,
@@ -13,7 +13,7 @@ jest.mock('react-router-dom', () => ({
 
 const mockedNavigate = jest.fn();
 
-const expectedHeaders = ["id", "Day", "Shift start", "Shift end", "Driver", "Backup driver"];
+const expectedHeaders = ["id", "Day", "Shift Start", "Shift End", "Driver", "Backup Driver"];
 const expectedFields = ["id", "day", "shiftStart", "shiftEnd", "driverID", "driverBackupID"];
 const testId = "ShiftTable";
 describe("ShiftTable tests", () => {
@@ -56,7 +56,7 @@ describe("ShiftTable tests", () => {
 
         expectedFields.forEach( (field)=> {
           const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
-          expect(header).toBeInTheDocument(); 
+          expect(header).toBeInTheDocument();
         });
 
         expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
@@ -75,7 +75,7 @@ describe("ShiftTable tests", () => {
 
       test("Has the expected column headers, content, and buttons for admin user", () => {
         const currentUser = currentUserFixtures.adminOnly;
-        
+
         render(
             <QueryClientProvider client={queryClient}>
                 <Router>
@@ -83,24 +83,24 @@ describe("ShiftTable tests", () => {
                 </Router>
             </QueryClientProvider>
         );
-    
+
         expectedHeaders.forEach((headerText) => {
             const header = screen.getByText(headerText);
             expect(header).toBeInTheDocument();
         });
-    
+
         expectedFields.forEach((field) => {
             const cellContent = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
             expect(cellContent).toBeInTheDocument();
         });
-    
+
         expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
         expect(screen.getByTestId(`${testId}-cell-row-0-col-day`)).toHaveTextContent("Monday");
-    
+
         const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
         expect(editButton).toBeInTheDocument();
         expect(editButton).toHaveClass("btn-primary");
-    
+
         const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
         expect(deleteButton).toBeInTheDocument();
         expect(deleteButton).toHaveClass("btn-danger");
@@ -112,7 +112,7 @@ describe("ShiftTable tests", () => {
 
     test("Has the expected column headers, content, and buttons for driver user", () => {
       const currentUser = currentUserFixtures.driverOnly;
-      
+
       render(
           <QueryClientProvider client={queryClient}>
               <Router>
@@ -120,17 +120,17 @@ describe("ShiftTable tests", () => {
               </Router>
           </QueryClientProvider>
       );
-  
+
       expectedHeaders.forEach((headerText) => {
           const header = screen.getByText(headerText);
           expect(header).toBeInTheDocument();
       });
-  
+
       expectedFields.forEach((field) => {
           const cellContent = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
           expect(cellContent).toBeInTheDocument();
       });
-  
+
       expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-day`)).toHaveTextContent("Monday");
 
@@ -138,10 +138,10 @@ describe("ShiftTable tests", () => {
       expect(infoButton).toBeInTheDocument();
       expect(infoButton).toHaveClass("btn-success");
   });
-    
+
     test("Has the expected column headers and content for an ordinary user", () => {
         const currentUser = currentUserFixtures.userOnly;
-    
+
         render(
             <QueryClientProvider client={queryClient}>
                 <Router>
@@ -149,20 +149,20 @@ describe("ShiftTable tests", () => {
                 </Router>
             </QueryClientProvider>
         );
-    
+
         expectedHeaders.forEach((headerText) => {
             const header = screen.getByText(headerText);
             expect(header).toBeInTheDocument();
         });
-    
+
         expectedFields.forEach((field) => {
             const cellContent = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
             expect(cellContent).toBeInTheDocument();
         });
-    
+
         expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
         expect(screen.getByTestId(`${testId}-cell-row-0-col-day`)).toHaveTextContent("Monday");
-    
+
         expect(screen.queryByText("Delete")).not.toBeInTheDocument();
         expect(screen.queryByText("Edit")).not.toBeInTheDocument();
         expect(screen.queryByText("Info")).not.toBeInTheDocument();
@@ -170,8 +170,8 @@ describe("ShiftTable tests", () => {
 
     test("Delete button calls delete callback", async () => {
         const currentUser = currentUserFixtures.adminUser;
-        
-        
+
+
         // act - render the component
         render(
           <QueryClientProvider client={queryClient}>
@@ -180,22 +180,22 @@ describe("ShiftTable tests", () => {
             </Router>
           </QueryClientProvider>
         );
-      
+
         // assert - check that the expected content is rendered
         expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
         expect(screen.getByTestId(`${testId}-cell-row-0-col-day`)).toHaveTextContent("Monday");
-      
+
         const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
         expect(deleteButton).toBeInTheDocument();
-      
+
         // act - click the delete button
         fireEvent.click(deleteButton);
       });
-    
+
 
       test("Edit button triggers navigation", async () => {
         const currentUser = currentUserFixtures.adminUser;
-      
+
         render(
           <QueryClientProvider client={queryClient}>
             <MemoryRouter>
@@ -203,19 +203,19 @@ describe("ShiftTable tests", () => {
             </MemoryRouter>
           </QueryClientProvider>
         );
-      
+
         // assert - check that the expected content is rendered
         expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
         const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
         expect(editButton).toBeInTheDocument();
-      
+
         // act - click the edit button
         fireEvent.click(editButton);
-      
+
         // assert - check if the mocked navigate function was called
         expect(mockedNavigate).toHaveBeenCalledWith('/shift/edit/1');
       });
-      
+
   test("Edit button navigates to the edit page", async () => {
     const currentUser = currentUserFixtures.adminUser;
 
@@ -243,7 +243,7 @@ describe("ShiftTable tests", () => {
 
     test("Info button triggers navigation", async () => {
       const currentUser = currentUserFixtures.adminUser;
-    
+
       render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter>
@@ -251,15 +251,15 @@ describe("ShiftTable tests", () => {
           </MemoryRouter>
         </QueryClientProvider>
       );
-    
+
       // assert - check that the expected content is rendered
       expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
       const infoButton = screen.getByTestId(`${testId}-cell-row-0-col-Info-button`);
       expect(infoButton).toBeInTheDocument();
-    
+
       // act - click the info button
       fireEvent.click(infoButton);
-    
+
       // assert - check if the mocked navigate function was called
       expect(mockedNavigate).toHaveBeenCalledWith('/shiftInfo/1');
     });


### PR DESCRIPTION
In this PR, I changed the capitalization of shift table headers and modified the corresponding tests to match. 
<img width="1470" alt="Screenshot 2024-05-17 at 11 49 58 AM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/61360955/03153a73-425d-4167-826f-3d8d7bfb1f17">

Closes #1 