### PR TITLE
Expose commit information at /api/systemInfo #12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add bash
 RUN apk add maven
 RUN apk add --no-cache libstdc++
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+RUN apk add git
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,7 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-RUN node --version
-RUN npm --version
-
-COPY frontend /home/app/frontend
-COPY src /home/app/src
-COPY lombok.config /home/app
-COPY pom.xml /home/app
+COPY . /home/app
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/pom.xml
+++ b/pom.xml
@@ -93,27 +93,6 @@
 
     <build>
         <plugins>
-        <plugin>
-                <groupId>com.cosium.code</groupId>
-                <artifactId>git-code-format-maven-plugin</artifactId>
-                <version>5.1</version>
-                <executions>
-                    <execution>
-                        <id>validate-code-format</id>
-                        <goals>
-                            <goal>validate-code-format</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <!-- Enable https://github.com/google/google-java-format -->
-                    <dependency>
-                        <groupId>com.cosium.code</groupId>
-                        <artifactId>google-java-format</artifactId>
-                        <version>5.1</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
             <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,12 @@
                         <phase>initialize</phase>
                     </execution>
                 </executions>
-                <configuration>
+                 <configuration>
+                        <includeOnlyProperties>
+                            <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+                            <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+                            <includeOnlyProperty>^git.commit.message.short$</includeOnlyProperty>
+                    </includeOnlyProperties>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
                     <commitIdGenerationMode>full</commitIdGenerationMode>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,25 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>8.0.2</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,27 @@
 
     <build>
         <plugins>
+        <plugin>
+                <groupId>com.cosium.code</groupId>
+                <artifactId>git-code-format-maven-plugin</artifactId>
+                <version>5.1</version>
+                <executions>
+                    <execution>
+                        <id>validate-code-format</id>
+                        <goals>
+                            <goal>validate-code-format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <!-- Enable https://github.com/google/google-java-format -->
+                    <dependency>
+                        <groupId>com.cosium.code</groupId>
+                        <artifactId>google-java-format</artifactId>
+                        <version>5.1</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>

--- a/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
@@ -14,4 +14,7 @@ import lombok.AccessLevel;
 public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
+  private String sourceRepo;
+  private String githubUrl;
+  private String commitId;
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
@@ -16,5 +16,6 @@ public class SystemInfo {
   private Boolean showSwaggerUILink;
   private String sourceRepo;
   private String githubUrl;
+  private String commitMessage;
   private String commitId;
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/models/SystemInfo.java
@@ -14,8 +14,10 @@ import lombok.AccessLevel;
 public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
+  private String startQtrYYYYQ;
+  private String endQtrYYYYQ;
   private String sourceRepo;
-  private String githubUrl;
   private String commitMessage;
   private String commitId;
+  private String githubUrl;
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -22,6 +22,12 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
+  @Value("${app.startQtrYYYYQ:20221}")
+  private String startQtrYYYYQ;
+  
+  @Value("${app.endQtrYYYYQ:20222}")
+  private String endQtrYYYYQ;
+
   @Value("${app.sourceRepo:https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5}")
   private String sourceRepo;
 
@@ -39,6 +45,8 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     SystemInfo si = SystemInfo.builder()
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
     .showSwaggerUILink(this.showSwaggerUILink)
+    .startQtrYYYYQ(this.startQtrYYYYQ)
+    .endQtrYYYYQ(this.endQtrYYYYQ)
     .sourceRepo(this.sourceRepo)
     .commitMessage(this.commitMessage)
     .commitId(this.commitId)

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -22,7 +22,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-gauchoride}")
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-gauchoride-s24-5pm-5}")
   private String sourceRepo;
 
   @Value("${git.commit.message.short:unknown}")

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -22,7 +22,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
-  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-gauchoride-s24-5pm-5}")
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5}")
   private String sourceRepo;
 
   @Value("${git.commit.message.short:unknown}")

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -22,10 +22,23 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
+  private String sourceRepo;
+
+  @Value("${git.commit.message.short:unknown}")
+  private String commitMessage;
+
+  @Value("${git.commit.id.abbrev:unknown}")
+  private String commitId;
+
+  public static String githubUrl(String repo, String commit) {
+    return commit != null && repo != null ? repo + "/commit/" + commit : null;
+  }
+
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
     .showSwaggerUILink(this.showSwaggerUILink)
+    .githubUrl(githubUrl(this.sourceRepo, this.commitId))
     .build();
   log.info("getSystemInfo returns {}",si);
   return si;

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -22,6 +22,7 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-gauchoride}")
   private String sourceRepo;
 
   @Value("${git.commit.message.short:unknown}")
@@ -38,6 +39,9 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     SystemInfo si = SystemInfo.builder()
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
     .showSwaggerUILink(this.showSwaggerUILink)
+    .sourceRepo(this.sourceRepo)
+    .commitMessage(this.commitMessage)
+    .commitId(this.commitId)
     .githubUrl(githubUrl(this.sourceRepo, this.commitId))
     .build();
   log.info("getSystemInfo returns {}",si);

--- a/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImpl.java
@@ -4,6 +4,8 @@ package edu.ucsb.cs156.gauchoride.services;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 import org.springframework.stereotype.Service;
 
 import edu.ucsb.cs156.gauchoride.models.SystemInfo;
@@ -13,6 +15,9 @@ import edu.ucsb.cs156.gauchoride.models.SystemInfo;
 
 @Slf4j
 @Service("systemInfo")
+@PropertySources(
+        @PropertySource("classpath:git.properties")
+)
 @ConfigurationProperties
 public class SystemInfoServiceImpl extends SystemInfoService {
   

--- a/src/test/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/services/SystemInfoServiceImplTests.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.gauchoride.services;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -34,6 +36,19 @@ class SystemInfoServiceImplTests  {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
+    assertTrue(si.getGithubUrl().startsWith(si.getSourceRepo()));
+    assertTrue(si.getGithubUrl().endsWith(si.getCommitId()));
+    assertTrue(si.getGithubUrl().contains("/commit/"));
   }
 
+  @Test
+  void test_githubUrl() {
+    assertEquals(
+        SystemInfoServiceImpl.githubUrl(
+            "https://github.com/ucsb-cs156/proj-courses", "abcdef12345"),
+        "https://github.com/ucsb-cs156/proj-courses/commit/abcdef12345");
+    assertNull(SystemInfoServiceImpl.githubUrl(null, null));
+    assertNull(SystemInfoServiceImpl.githubUrl("x", null));
+    assertNull(SystemInfoServiceImpl.githubUrl(null, "x"));
+  }
 }


### PR DESCRIPTION
From issue description:
- As a developer
- I can see information about the latest commit deployed to a deployment on dokku or localhost
- So that I am more aware of which commit is deployed on running code
- On Dokku, and on localhost, the /api/systemInfo shows the correct commit info about the most recent commit deployed to that deployment

[dokku link](https://tommy-dev.dokku-13.cs.ucsb.edu)

<img width="716" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/79723996/14688998-8256-49f0-acaf-0e6d7737b516">


Closes #12