### PR TITLE
Adjusted DriversController API Access

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
@@ -36,7 +36,7 @@ public class DriversController extends ApiController{
     ObjectMapper mapper;
 
     @Operation(summary = "Get a list of all drivers")
-    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
     @GetMapping("/all")
     public ResponseEntity<String> drivers()
             throws JsonProcessingException {
@@ -48,7 +48,7 @@ public class DriversController extends ApiController{
     }
 
     @Operation(summary = "Get user by id")
-    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
     @GetMapping("/get")
     public DriverInfo driver(
             @Parameter(name = "id", description = "Long, id number of user to get", example = "1", required = true) @RequestParam Long id)


### PR DESCRIPTION
Previously, the DriversController API was specified such that even regular users could get information about all and specific drivers. I modified the hasRole authorization to ensure that only drivers and admins could access this information. I further ensured that all the test cases for the project were still passing after making this change. Now when logged in as a user, you can not access the api/drivers/ endpoint as seen below:
<img width="1437" alt="Screenshot 2024-05-18 at 2 03 12 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/38393239/09da741b-bec4-40e1-9444-fb491591fde6">

Closes #10 