### PR TITLE
Fixes labels/bad input/example input for Improve usability of the DriverAvailabilities Create Page #13

### DIFF
--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -124,6 +124,8 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                     {...register("notes", {
                         required: "Notes are required."
                     })}
+                    placeholder="e.g. Busy on Monday"  
+                    defaultValue={initialContents?.notes} 
                 />
                 <Form.Control.Feedback type="invalid">
                     {errors.notes?.message}

--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -11,7 +11,7 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
     } = useForm(
         { defaultValues: initialContents || {}, }
     );
-    // Stryker enable all
+    // Stryker restore all
     const navigate = useNavigate();
 
     const testIdPrefix = "DriverAvailabilityForm";

--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -11,7 +11,7 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
     } = useForm(
         { defaultValues: initialContents || {}, }
     );
-    // Stryker restore all
+    // Stryker enable all
     const navigate = useNavigate();
 
     const testIdPrefix = "DriverAvailabilityForm";

--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -122,7 +122,6 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                     type="text"
                     isInvalid={Boolean(errors.notes)}
                     {...register("notes", {
-                        // required: "Notes are required."
                     })}
                     placeholder="e.g. Busy on Monday"  
                     defaultValue={initialContents?.notes} 

--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -47,31 +47,45 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="day">day</Form.Label>
-                <Form.Control
+                <Form.Label htmlFor="day">Day of Week</Form.Label>
+                <Form.Select
                     data-testid={testIdPrefix + "-day"}
                     id="day"
-                    type="text"
                     isInvalid={Boolean(errors.day)}
                     {...register("day", {
-                        required: "day is required."
+                        required: "Day is required.",
                     })}
-                />
+                >
+                <option value="">Select a Day</option>
+                <option value="Monday">Monday</option>
+                <option value="Tuesday">Tuesday</option>
+                <option value="Wednesday">Wednesday</option>
+                <option value="Thursday">Thursday</option>
+                <option value="Friday">Friday</option>
+                <option value="Saturday">Saturday</option>
+                <option value="Sunday">Sunday</option>
+                </Form.Select>
                 <Form.Control.Feedback type="invalid">
                     {errors.day?.message}
                 </Form.Control.Feedback>
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="startTime">startTime</Form.Label>
+                <Form.Label htmlFor="startTime">Availability Start</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-startTime"}
                     id="startTime"
                     type="text"
                     isInvalid={Boolean(errors.startTime)}
                     {...register("startTime", {
-                        required: "startTime is required."
+                        required: "Availability Start is required.",
+                        pattern: {
+                            value: /^(0?[1-9]|1[0-2]):[0-5][0-9](AM|PM)$/,
+                            message: "Please enter time in the format HH:MM AM/PM (e.g., 3:30PM)."
+                          }
                     })}
+                    placeholder="Enter time in the format HH:MM AM/PM (e.g. 3:30PM)"
+                    defaultValue={initialContents?.startTime}
                 />
                 <Form.Control.Feedback type="invalid">
                     {errors.startTime?.message}
@@ -79,15 +93,21 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="endTime">endTime</Form.Label>
+                <Form.Label htmlFor="endTime">Availability End</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-endTime"}
                     id="endTime"
                     type="text"
                     isInvalid={Boolean(errors.endTime)}
                     {...register("endTime", {
-                        required: "endTime is required."
+                        required: "Availability End is required.",
+                        pattern: {
+                            value: /^(0?[1-9]|1[0-2]):[0-5][0-9](AM|PM)$/,
+                            message: "Please enter time in the format HH:MM AM/PM (e.g., 3:30PM)."
+                          }
                     })}
+                    placeholder="Enter time in the format HH:MM AM/PM (e.g. 3:30PM)"
+                    defaultValue={initialContents?.endTime}
                 />
                 <Form.Control.Feedback type="invalid">
                     {errors.endTime?.message}
@@ -95,14 +115,14 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="notes">notes</Form.Label>
+                <Form.Label htmlFor="notes">Notes</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-notes"}
                     id="notes"
                     type="text"
                     isInvalid={Boolean(errors.notes)}
                     {...register("notes", {
-                        required: "notes is required."
+                        required: "Notes are required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">

--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -81,7 +81,7 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                         required: "Availability Start is required.",
                         pattern: {
                             value: /^(0?[1-9]|1[0-2]):[0-5][0-9](AM|PM)$/,
-                            message: "Please enter time in the format HH:MM AM/PM (e.g., 3:30PM)."
+                            message: "Please enter start time in the format HH:MM AM/PM (e.g., 3:30PM)."
                           }
                     })}
                     placeholder="Enter time in the format HH:MM AM/PM (e.g. 3:30PM)"
@@ -103,7 +103,7 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                         required: "Availability End is required.",
                         pattern: {
                             value: /^(0?[1-9]|1[0-2]):[0-5][0-9](AM|PM)$/,
-                            message: "Please enter time in the format HH:MM AM/PM (e.g., 3:30PM)."
+                            message: "Please enter end time in the format HH:MM AM/PM (e.g., 3:30PM)."
                           }
                     })}
                     placeholder="Enter time in the format HH:MM AM/PM (e.g. 3:30PM)"

--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -122,7 +122,7 @@ function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "
                     type="text"
                     isInvalid={Boolean(errors.notes)}
                     {...register("notes", {
-                        required: "Notes are required."
+                        // required: "Notes are required."
                     })}
                     placeholder="e.g. Busy on Monday"  
                     defaultValue={initialContents?.notes} 

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -110,6 +110,48 @@ describe("DriverAvailabilityForm tests", () => {
 
     });
 
+    test("enter wrong time format", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <DriverAvailabilityForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+        const submitButton = screen.getByText(/Create/);
+        const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
+        const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
+        fireEvent.change(startTimeField, { target: { value: 'BAD' } });
+        fireEvent.change(endTimeField, { target: { value: 'BAD' } });
+        fireEvent.click(submitButton);
+
+        await screen.findByText(/driverId is required./);
+        expect(screen.getByText("Please enter start time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument();
+        expect(screen.getByText("Please enter end time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument();
+        expect(screen.getByText(/Day is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Notes are required./)).toBeInTheDocument();
+
+        fireEvent.change(startTimeField, { target: { value: 'BAD 3:30PM' } });
+        fireEvent.change(endTimeField, { target: { value: 'BAD 3:30PM' } });
+        await screen.findByText(/driverId is required./);
+        expect(screen.getByText("Please enter start time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument();
+        expect(screen.getByText("Please enter end time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument();
+        
+        fireEvent.change(startTimeField, { target: { value: 'BAD 3:30PM BAD' } });
+        fireEvent.change(endTimeField, { target: { value: 'BAD 3:30PM BAD' } });
+        await screen.findByText(/driverId is required./);
+        expect(screen.getByText("Please enter start time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument();
+        expect(screen.getByText("Please enter end time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument();
+
+        fireEvent.change(startTimeField, { target: { value: '3:30PM BAD' } });
+        fireEvent.change(endTimeField, { target: { value: '3:30PM BAD' } });
+        await screen.findByText(/driverId is required./);
+        expect(screen.getByText("Please enter start time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument();
+        expect(screen.getByText("Please enter end time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument();
+    });
+
     test("No Error messsages on good input", async () => {
 
         const mockSubmitAction = jest.fn();
@@ -142,6 +184,8 @@ describe("DriverAvailabilityForm tests", () => {
         expect(screen.queryByText(/Day is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Availability Start is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Availability End is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText("Please enter start time in the format HH:MM AM/PM (e.g., 3:30PM).")).not.toBeInTheDocument();
+        expect(screen.queryByText("Please enter end time in the format HH:MM AM/PM (e.g., 3:30PM).")).not.toBeInTheDocument();
         expect(screen.queryByText(/Notes are required./)).not.toBeInTheDocument();
 
 

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -60,16 +60,16 @@ describe("DriverAvailabilityForm tests", () => {
         expect(screen.getByText(`driverId`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-day`)).toBeInTheDocument();
-        expect(screen.getByText(`day`)).toBeInTheDocument();
+        expect(screen.getByText(`Day of Week`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-startTime`)).toBeInTheDocument();
-        expect(screen.getByText(`startTime`)).toBeInTheDocument();
+        expect(screen.getByText(`Availability Start`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-endTime`)).toBeInTheDocument();
-        expect(screen.getByText(`endTime`)).toBeInTheDocument();
+        expect(screen.getByText(`Availability End`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-notes`)).toBeInTheDocument();
-        expect(screen.getByText(`notes`)).toBeInTheDocument();
+        expect(screen.getByText(`Notes`)).toBeInTheDocument();
     });
 
 
@@ -105,7 +105,7 @@ describe("DriverAvailabilityForm tests", () => {
         await screen.findByText(/driverId is required./);
         expect(screen.getByText(/Day is required./)).toBeInTheDocument();
         expect(screen.getByText(/Availability Start is required./)).toBeInTheDocument();
-        expect(screen.getByText(/Availability End required./)).toBeInTheDocument();
+        expect(screen.getByText(/Availability End is required./)).toBeInTheDocument();
         expect(screen.getByText(/Notes are required./)).toBeInTheDocument();
 
     });
@@ -130,9 +130,9 @@ describe("DriverAvailabilityForm tests", () => {
         const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
 
         fireEvent.change(driverIdField, { target: { value: 'test' } });
-        fireEvent.change(dayField, { target: { value: 'test' } });
-        fireEvent.change(startTimeField, { target: { value: 'test' } });
-        fireEvent.change(endTimeField, { target: { value: 'test' } });
+        fireEvent.change(dayField, { target: { value: 'Monday' } });
+        fireEvent.change(startTimeField, { target: { value: '3:30PM' } });
+        fireEvent.change(endTimeField, { target: { value: '3:30PM' } });
         fireEvent.change(notesField, { target: { value: 'test' } });
         fireEvent.click(submitButton);
 
@@ -141,7 +141,7 @@ describe("DriverAvailabilityForm tests", () => {
         expect(screen.queryByText(/driverId is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Day is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Availability Start is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/Availability End required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Availability End is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Notes are required./)).not.toBeInTheDocument();
 
 

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -106,7 +106,6 @@ describe("DriverAvailabilityForm tests", () => {
         expect(screen.getByText(/Day is required./)).toBeInTheDocument();
         expect(screen.getByText(/Availability Start is required./)).toBeInTheDocument();
         expect(screen.getByText(/Availability End is required./)).toBeInTheDocument();
-        expect(screen.getByText(/Notes are required./)).toBeInTheDocument();
 
     });
 
@@ -131,7 +130,6 @@ describe("DriverAvailabilityForm tests", () => {
         expect(screen.getByText("Please enter start time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument();
         expect(screen.getByText("Please enter end time in the format HH:MM AM/PM (e.g., 3:30PM).")).toBeInTheDocument();
         expect(screen.getByText(/Day is required./)).toBeInTheDocument();
-        expect(screen.getByText(/Notes are required./)).toBeInTheDocument();
 
         fireEvent.change(startTimeField, { target: { value: 'BAD 3:30PM' } });
         fireEvent.change(endTimeField, { target: { value: 'BAD 3:30PM' } });
@@ -186,7 +184,6 @@ describe("DriverAvailabilityForm tests", () => {
         expect(screen.queryByText(/Availability End is required./)).not.toBeInTheDocument();
         expect(screen.queryByText("Please enter start time in the format HH:MM AM/PM (e.g., 3:30PM).")).not.toBeInTheDocument();
         expect(screen.queryByText("Please enter end time in the format HH:MM AM/PM (e.g., 3:30PM).")).not.toBeInTheDocument();
-        expect(screen.queryByText(/Notes are required./)).not.toBeInTheDocument();
 
 
     });

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -16,7 +16,7 @@ jest.mock('react-router-dom', () => ({
 describe("DriverAvailabilityForm tests", () => {
     const queryClient = new QueryClient();
 
-    const expectedHeaders = ["driverId", "day", "startTime", "endTime", "notes"];
+    const expectedHeaders = ["driverId", "Day of Week", "Availability Start", "Availability End", "Notes"];
     const testId = "DriverAvailabilityForm";
 
     test("renders correctly with no initialContents", async () => {
@@ -103,10 +103,10 @@ describe("DriverAvailabilityForm tests", () => {
         fireEvent.click(submitButton);
 
         await screen.findByText(/driverId is required./);
-        expect(screen.getByText(/day is required./)).toBeInTheDocument();
-        expect(screen.getByText(/startTime is required./)).toBeInTheDocument();
-        expect(screen.getByText(/endTime is required./)).toBeInTheDocument();
-        expect(screen.getByText(/notes is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Day is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Availability Start is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Availability End required./)).toBeInTheDocument();
+        expect(screen.getByText(/Notes are required./)).toBeInTheDocument();
 
     });
 
@@ -139,10 +139,10 @@ describe("DriverAvailabilityForm tests", () => {
         await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
 
         expect(screen.queryByText(/driverId is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/day is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/startTime is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/endTime is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/notes is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Day is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Availability Start is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Availability End required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Notes are required./)).not.toBeInTheDocument();
 
 
     });

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
@@ -87,16 +87,16 @@ describe("DriverAvailabilityCreatePage tests", () => {
             expect(driverIdInput).toBeInTheDocument();
         });
 
-        const dayInput = screen.getByLabelText("day");
+        const dayInput = screen.getByLabelText("Day of Week");
         expect(dayInput).toBeInTheDocument();
 
-        const startTimeInput = screen.getByLabelText("startTime");
+        const startTimeInput = screen.getByLabelText("Availability Start");
         expect(startTimeInput).toBeInTheDocument();
 
-        const endTimeInput = screen.getByLabelText("endTime");
+        const endTimeInput = screen.getByLabelText("Availability End");
         expect(endTimeInput).toBeInTheDocument();
 
-        const notesInput = screen.getByLabelText("notes");
+        const notesInput = screen.getByLabelText("Notes");
         expect(notesInput).toBeInTheDocument();
 
         // Simulating filling out the form


### PR DESCRIPTION
[DOKKU](https://tommy-dev.dokku-13.cs.ucsb.edu/)

Does part of EPIC issue [13](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/issues/13). 

Closes #32  (Made day of week a dropdown, only able to select day of week)

Note: Did not change driverId since we will remove this later on in the EPIC. Only front-end changes.

- The form labels are improved
- The bad input and missing input error messages are added and improved
- Example inputs on each form field
- Dropdown for choosing day instead of free form

BEFORE:
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/79723996/d7051c08-4f5d-4cc4-b43e-f0e5cbb03c83)

![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/79723996/9f94b7ec-37f0-4e78-9b41-f1e30722608d)


AFTER

![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/79723996/a05756b2-7001-4432-bc3d-dfca1278181b)
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/79723996/369dd3bf-544a-450d-9818-4753d4fd9d96)
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/79723996/f7ff7f69-257a-4518-b33f-19452a20a758)


Code modeled from `RideForm.js`
