### PR TITLE
WG - Updated which tabs appear based on user roles

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -90,7 +90,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                hasRole(currentUser, "ROLE_ADMIN") && isParticipant(currentUser) && (
+                hasRole(currentUser, "ROLE_ADMIN")  && (
                   <NavDropdown title="Shifts" id="appnavbar-shift-dropdown" data-testid="appnavbar-shift-dropdown" >
                     <NavDropdown.Item data-testid="appnavbar-shift-dropdown-shifts" as={Link} to="/shift/">Shifts</NavDropdown.Item>
                   </NavDropdown>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -90,7 +90,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                !hasRole(currentUser, "ROLE_DRIVER") && isParticipant(currentUser) && (
+                hasRole(currentUser, "ROLE_ADMIN") && isParticipant(currentUser) && (
                   <NavDropdown title="Shifts" id="appnavbar-shift-dropdown" data-testid="appnavbar-shift-dropdown" >
                     <NavDropdown.Item data-testid="appnavbar-shift-dropdown-shifts" as={Link} to="/shift/">Shifts</NavDropdown.Item>
                   </NavDropdown>
@@ -120,7 +120,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                isParticipant(currentUser) && (
+                hasRole(currentUser, "ROLE_DRIVER") && (
                   <Nav.Link id ="appnavbar-driver-link" data-testid="appnavbar-driver" as={Link} to="/drivers/list">Drivers Page</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -120,7 +120,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                hasRole(currentUser, "ROLE_DRIVER") && (
+                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && (
                   <Nav.Link id ="appnavbar-driver-link" data-testid="appnavbar-driver" as={Link} to="/drivers/list">Drivers Page</Nav.Link>
                 )
               }

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -193,8 +193,8 @@ describe("AppNavbar tests", () => {
         );
         
         await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
-        const shiftMenu = getByTestId("appnavbar-shift-dropdown");
-        expect(shiftMenu).toBeInTheDocument();        
+        const rideMenu = getByTestId("appnavbar-ride-dropdown");
+        expect(rideMenu).toBeInTheDocument();        
     });
 
     test("not render shift table links for regular user", async () => {


### PR DESCRIPTION
When the user only has "Rider" set to true, the navbar only shows "Ride Request" dropdown. 

- Only shows "Shifts" dropdown if the user is an "Admin"
- Only shows "Drivers Page" button if the user is an "Admin" or a "Driver"

<img width="1137" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/91863546/b4fb0088-1411-4535-98aa-863db5e123b3">

<img width="674" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/91863546/9926b603-d283-4959-898a-46ce2348e0b8">

Closes #11 