### PR TITLE
Fix BUG: Github repo link is hardcoded #18

### DIFF
--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -26,7 +26,6 @@ export default function Footer({systemInfo}) {
           <a
             data-testid="footer-source-code-link"
             href={repoUrl}
-            // use api/systemInfo to get the repo URL
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Container } from "react-bootstrap";
 export const space = " ";
 
-export default function Footer(syst) {
+export default function Footer({systemInfo}) {
   return (
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { Container } from "react-bootstrap";
 export const space = " ";
 

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -25,7 +25,7 @@ export default function Footer({systemInfo}) {
           {space}
           <a
             data-testid="footer-source-code-link"
-            href={repoUrl}
+            href={systemInfo?.sourceRepo}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -2,15 +2,7 @@ import { useEffect, useState } from "react";
 import { Container } from "react-bootstrap";
 export const space = " ";
 
-export default function Footer() {
-  const [repoUrl, setRepoUrl] = useState("");
-  useEffect(() => { 
-    fetch("/api/systemInfo")
-      // .then((res) => res.json())
-      .then((data) => {
-        setRepoUrl(data.sourceRepo);
-      });
-  }, []);
+export default function Footer(syst) {
   return (
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -1,8 +1,16 @@
+import { useEffect, useState } from "react";
 import { Container } from "react-bootstrap";
-
 export const space = " ";
 
 export default function Footer() {
+  const [repoUrl, setRepoUrl] = useState("");
+  useEffect(() => { 
+    fetch("/api/systemInfo")
+      .then((res) => res.json())
+      .then((data) => {
+        setRepoUrl(data.sourceRepo);
+      });
+  }, []);
   return (
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>
@@ -26,7 +34,8 @@ export default function Footer() {
           {space}
           <a
             data-testid="footer-source-code-link"
-            href={"https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-2"}
+            href={repoUrl}
+            // use api/systemInfo to get the repo URL
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -6,7 +6,7 @@ export default function Footer() {
   const [repoUrl, setRepoUrl] = useState("");
   useEffect(() => { 
     fetch("/api/systemInfo")
-      .then((res) => res.json())
+      // .then((res) => res.json())
       .then((data) => {
         setRepoUrl(data.sourceRepo);
       });

--- a/frontend/src/main/layouts/BasicLayout/BasicLayout.js
+++ b/frontend/src/main/layouts/BasicLayout/BasicLayout.js
@@ -14,6 +14,7 @@ export default function BasicLayout({ children }) {
   return (
     <div className="d-flex flex-column min-vh-100">
       <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogout={doLogout} />
+      <Footer systemInfo={systemInfo} />
       <Container expand="xl" className="pt-4 flex-grow-1">
         {children}
       </Container>

--- a/frontend/src/main/layouts/BasicLayout/BasicLayout.js
+++ b/frontend/src/main/layouts/BasicLayout/BasicLayout.js
@@ -14,11 +14,10 @@ export default function BasicLayout({ children }) {
   return (
     <div className="d-flex flex-column min-vh-100">
       <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogout={doLogout} />
-      <Footer systemInfo={systemInfo} />
       <Container expand="xl" className="pt-4 flex-grow-1">
         {children}
       </Container>
-      <Footer/>
+      <Footer systemInfo={systemInfo} />
     </div>
   );
 }

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -29,7 +29,8 @@ describe("Footer tests", () => {
             "commitId": "c65b37b",
             "githubUrl": "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/commit/c65b37b"
           })
-        render(<Footer />)
+        const systemInfo = { sourceRepo: "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5"};
+        render(<Footer systemInfo={systemInfo} />)
         expect(screen.getByTestId("footer-class-website-link")).toHaveAttribute(
             "href",
             "https://ucsb-cs156.github.io"

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -1,10 +1,7 @@
 import { render, waitFor, screen } from "@testing-library/react";
 import Footer, { space } from "main/components/Nav/Footer";
-import axios from "axios";
-import AxiosMockAdapter from "axios-mock-adapter";
 
 describe("Footer tests", () => {
-    const axiosMock =new AxiosMockAdapter(axios);
 
     test("renders correctly ", async () => {
         const { getByText } = render(

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -1,7 +1,11 @@
 import { render, waitFor, screen } from "@testing-library/react";
 import Footer, { space } from "main/components/Nav/Footer";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
 
 describe("Footer tests", () => {
+    const axiosMock =new AxiosMockAdapter(axios);
+
     test("renders correctly ", async () => {
         const { getByText } = render(
             <Footer />
@@ -15,6 +19,16 @@ describe("Footer tests", () => {
     });
 
     test("Links are correct", async () => {
+        axiosMock.onGet("/api/systemInfo").reply(200, {
+            "springH2ConsoleEnabled": true,
+            "showSwaggerUILink": true,
+            "startQtrYYYYQ": "20221",
+            "endQtrYYYYQ": "20222",
+            "sourceRepo": "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5",
+            "commitMessage": "add missing values",
+            "commitId": "c65b37b",
+            "githubUrl": "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/commit/c65b37b"
+          })
         render(<Footer />)
         expect(screen.getByTestId("footer-class-website-link")).toHaveAttribute(
             "href",
@@ -24,10 +38,11 @@ describe("Footer tests", () => {
             "href",
             "https://ucsb.edu"
         );
-        expect(screen.getByTestId("footer-source-code-link")).toHaveAttribute(
-            "href",
-            "https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-2"
-        );
+        console.log(screen.getByTestId("footer-source-code-link"))
+        // expect(screen.getByTestId("footer-source-code-link")).toHaveAttribute(
+        //     "href",
+        //     "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5"
+        // );
         expect(screen.getByTestId("footer-sticker-link")).toHaveAttribute(
             "href",
             "https://www.as.ucsb.edu/sticker-packs"

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -40,10 +40,10 @@ describe("Footer tests", () => {
             "https://ucsb.edu"
         );
         console.log(screen.getByTestId("footer-source-code-link"))
-        // expect(screen.getByTestId("footer-source-code-link")).toHaveAttribute(
-        //     "href",
-        //     "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5"
-        // );
+        expect(screen.getByTestId("footer-source-code-link")).toHaveAttribute(
+             "href",
+             "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5"
+         );
         expect(screen.getByTestId("footer-sticker-link")).toHaveAttribute(
             "href",
             "https://www.as.ucsb.edu/sticker-packs"

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -19,17 +19,16 @@ describe("Footer tests", () => {
     });
 
     test("Links are correct", async () => {
-        axiosMock.onGet("/api/systemInfo").reply(200, {
-            "springH2ConsoleEnabled": true,
-            "showSwaggerUILink": true,
-            "startQtrYYYYQ": "20221",
-            "endQtrYYYYQ": "20222",
-            "sourceRepo": "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5",
-            "commitMessage": "add missing values",
-            "commitId": "c65b37b",
-            "githubUrl": "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/commit/c65b37b"
-          })
-        const systemInfo = { sourceRepo: "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5"};
+        const systemInfo = {
+            springH2ConsoleEnabled: true,
+            showSwaggerUILink: true,
+            startQtrYYYYQ: "20221",
+            endQtrYYYYQ: "20222",
+            sourceRepo: "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5",
+            commitMessage: "add missing values",
+            commitId: "c65b37b",
+            githubUrl: "https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/commit/c65b37b"
+          };
         render(<Footer systemInfo={systemInfo} />)
         expect(screen.getByTestId("footer-class-website-link")).toHaveAttribute(
             "href",

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -2,7 +2,6 @@ import { render, waitFor, screen } from "@testing-library/react";
 import Footer, { space } from "main/components/Nav/Footer";
 
 describe("Footer tests", () => {
-
     test("renders correctly ", async () => {
         const { getByText } = render(
             <Footer />


### PR DESCRIPTION
[dokku](https://tommy-dev.dokku-13.cs.ucsb.edu)

When clicking the Github hyperlink on the footer, the link routes to a hardcoded github repo. Instead this should be dynamic and be based on the repo specified in the system info. By default the link can go to proj-gauchoride in the ucsb-cs156 organization. This also requires the issue "FEATURE - expose commit infomation at /api/systemInfo" to be completed, since that issue adds the github repo to the system info.

After the issue "FEATURE - expose commit infomation at /api/systemInfo" is completed, modify Footer.js to use the systeminfo instead of a hardcoded value.

UPDATE:
- resolved issues with incorrect testing and param usage

Closes #18 