### PR TITLE
FEATURE and DOCUMENTATION: Make /api/systemInfo available even when not logged in, AND document dokku step. #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,7 @@ On Heroku:
 * The SQL database is a postgres database provisioned automatically by Heroku
 * You can reset it with `heroku pg:reset --app app-name-goes-here`
 * More info and instructions for access the SQL prompt are at [docs/postgres-database.md](/docs/postgres-database.md)
+
+# Important step for Dokku deployment
+* Run this command to keep the git directory in the Dokku app:
+```dokku git:set appname keep-git-dir true```

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/SystemInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/SystemInfoController.java
@@ -26,7 +26,6 @@ public class SystemInfoController extends ApiController {
     private SystemInfoService systemInfoService;
 
     @Operation(summary = "Get global information about the application")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("")
     public SystemInfo getSystemInfo() {
         return systemInfoService.getSystemInfo();

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/SystemInfoControllerTests.java
@@ -29,14 +29,14 @@ public class SystemInfoControllerTests extends ControllerTestCase {
   @Test
   public void systemInfo__logged_out() throws Exception {
     mockMvc.perform(get("/api/systemInfo"))
-        .andExpect(status().is(403));
+        .andExpect(status().isOk()).andReturn();
   }
 
   @WithMockUser(roles = { "USER" })
   @Test
   public void systemInfo__user_logged_in() throws Exception {
     mockMvc.perform(get("/api/systemInfo"))
-        .andExpect(status().is(403));
+        .andExpect(status().isOk()).andReturn();
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })


### PR DESCRIPTION
This PR addresses two things that are needed now that the PR to expose git commit information has been merged:

- Making /api/systemInfo an unprotected endpoint (It was always intended to be available even when not logged in)
- Documenting the extra dokku step needed to deploy.


Can see /api/systemInfo when logged out.
Changed tests to support this change

![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/79723996/3ce15a18-7884-4670-b9c6-9ab3cdb9a6c9)


Closes #38 