### PR TITLE
WG - Refactored how code checks participants role

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -121,7 +121,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                isParticipant(currentUser) && !hasRole(currentUser, "ROLE_RIDER") && (
+                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && (
                   <Nav.Link id ="appnavbar-driver-link" data-testid="appnavbar-driver" as={Link} to="/drivers/list">Drivers Page</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -121,7 +121,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN")) && (
+                isParticipant(currentUser) && !hasRole(currentUser, "ROLE_RIDER") && (
                   <Nav.Link id ="appnavbar-driver-link" data-testid="appnavbar-driver" as={Link} to="/drivers/list">Drivers Page</Nav.Link>
                 )
               }

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -601,7 +601,7 @@ describe("AppNavbar tests", () => {
     });
 
     test("Driver page link should appear for a user that is a adminOnlyNoUser", async () => {
-        const currentUser = currentUserFixtures.adminOnlyNoUser;
+        const currentUser = currentUserFixtures.adminOnly;
         const doLogin = jest.fn();
 
         const { getByText } = render(

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -582,6 +582,74 @@ describe("AppNavbar tests", () => {
         const driverLink = screen.queryByTestId("appnavbar-driver");
         expect(driverLink).toBeInTheDocument();      
     });
+
+    test("Driver page link should appear for a user that is a driver", async () => {
+        const currentUser = currentUserFixtures.driverOnly;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
+        const driverLink = screen.queryByTestId("appnavbar-driver");
+        expect(driverLink).toBeInTheDocument();      
+    });
+
+    test("Driver page link should appear for a user that is a adminOnlyNoUser", async () => {
+        const currentUser = currentUserFixtures.adminOnlyNoUser;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByText("Welcome, Phill Conrad")).toBeInTheDocument());
+        const driverLink = screen.queryByTestId("appnavbar-driver");
+        expect(driverLink).toBeInTheDocument();      
+    });
+
+    test("Driver page link should appear for a user that is an admin", async () => {
+        const currentUser = currentUserFixtures.adminUser;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByText("Welcome, Phill Conrad")).toBeInTheDocument());
+        const driverLink = screen.queryByTestId("appnavbar-driver");
+        expect(driverLink).toBeInTheDocument();      
+    });
+
+    test("Driver page link should NOT appear for a user that is only a rider", async () => {
+        const currentUser = currentUserFixtures.riderOnly;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
+        const driverLink = screen.queryByTestId("appnavbar-driver");
+        expect(driverLink).not.toBeInTheDocument();      
+    });
         
     test("renders RiderApplicationMember links correctly for member", async () => {
 

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -600,7 +600,7 @@ describe("AppNavbar tests", () => {
         expect(driverLink).toBeInTheDocument();      
     });
 
-    test("Driver page link should appear for a user that is a adminOnlyNoUser", async () => {
+    test("Driver page link should appear for a user that is a adminOnly", async () => {
         const currentUser = currentUserFixtures.adminOnly;
         const doLogin = jest.fn();
 


### PR DESCRIPTION
Previously, to ensure that the participant didn't have "ROLE_USER", there was a check looking to see if the participant had "ROLE_ADMIN" or "ROLE_DRIVER". This closed issue #30, which removed some tabs from appearing in the navbar for "ROLE_USER" participants.

The change in this PR checks that participant doesn't have "ROLE_USER" in a different way, which should fix some mutation issues that seem to have come from the previously closed issue.

NOTE: The GitHub actions for branches don't run the test  `npx stryker run --incremental --incrementalFile reports/stryker-incremental-main.json`. It might be beneficial to add these to the GitHub actions since this error went overlooked for a while, but it would likely come at the cost of longer GitHub actions test runtime.
Running the above command locally allowed me to reproduce the mutation error that is in main as shown:
<img width="819" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/91863546/18b29d41-a1a6-475b-ae05-e83dab43a7d2">

When running the command with the change made in this PR, that mutation test was successful: 
<img width="1012" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/91863546/a19b2434-96d1-4669-a3d2-419969a1e599">