### PR TITLE
Added new Scheduler page and related components

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -34,6 +34,8 @@ import RiderApplicationShowPageMember from "main/pages/RiderApplication/RiderApp
 import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
 import RiderApplicationEditPageAdmin from "main/pages/RiderApplication/RiderApplicationEditPageAdmin";
 
+import SchedulerPage from "main/pages/Scheduler/SchedulerPage";
+
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";  
@@ -130,6 +132,12 @@ function App() {
         }
         {
           (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/availability/review/:id" element={<DriverAvailabilityEditPage />} />
+        }
+        {
+          (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/schedule" element={<SchedulerPage />} />
+        }
+        {
+          (hasRole(currentUser, "ROLE_ADMIN")) && <Route exact path="/admin/schedule/:page" element={<SchedulerPage />} />
         }
         <Route exact path="/privacy.html" />
         <Route exact path="/*" element={<PageNotFound />} />

--- a/frontend/src/fixtures/scheduleEventsFixtures.js
+++ b/frontend/src/fixtures/scheduleEventsFixtures.js
@@ -1,0 +1,88 @@
+const scheduleEventsFixtures = {
+    oneEvent: {
+        id: 1,
+        title: "Team Meeting",
+        day: "Monday",
+        startTime: "10:00AM",
+        endTime: "11:00AM",
+        description: "Discuss project progress"
+    },
+    threeEvents: [
+        {
+            id: 1,
+            title: "Team Meeting",
+            day: "Monday",
+            startTime: "10:00AM",
+            endTime: "11:00AM",
+            description: "Discuss project progress"
+        },
+        {
+            id: 2,
+            title: "Client Call",
+            day: "Wednesday",
+            startTime: "01:30PM",
+            endTime: "02:30PM",
+            description: "Monthly update call with the client"
+        },
+        {
+            id: 3,
+            title: "Workshop",
+            day: "Friday",
+            startTime: "09:00AM",
+            endTime: "12:00PM",
+            description: "React.js workshop"
+        }
+    ],
+    sixEvents: [
+        {
+            id: 1,
+            title: "Team Meeting",
+            day: "Monday",
+            startTime: "10:00AM",
+            endTime: "11:00AM",
+            description: "Discuss project progress"
+        },
+        {
+            id: 2,
+            title: "Client Call",
+            day: "Wednesday",
+            startTime: "01:30PM",
+            endTime: "02:30PM",
+            description: "Monthly update call with the client update call with the client update call with the client"
+        },
+        {
+            id: 3,
+            title: "Workshop Workshop Workshop",
+            day: "Friday",
+            startTime: "09:00AM",
+            endTime: "12:00PM",
+            description: "React.js workshop"
+        },
+        {
+            id: 4,
+            title: "Design Review Review Review",
+            day: "Tuesday",
+            startTime: "03:19PM",
+            endTime: "04:00PM",
+            description: "Review new designs"
+        },
+        {
+            id: 5,
+            title: "Sprint Planning",
+            day: "Thursday",
+            startTime: "11:00AM",
+            endTime: "12:30PM",
+            description: "Plan tasks for the next sprint"
+        },
+        {
+            id: 6,
+            title: "Code Review",
+            day: "Monday",
+            startTime: "02:00PM",
+            endTime: "03:00PM",
+            description: "Review code submissions"
+        }
+    ]
+}
+
+export { scheduleEventsFixtures };

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -80,6 +80,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                     <NavDropdown.Item as={Link} to="/admin/users">Users</NavDropdown.Item>
                     <NavDropdown.Item as={Link} to="/admin/driverAvailability">Driver Availabilities</NavDropdown.Item>
                     <NavDropdown.Item as={Link} to="/admin/applications/riders">Rider Applications</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/admin/schedule">Schedule</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -91,7 +91,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                hasRole(currentUser, "ROLE_ADMIN")  && (
+                hasRole(currentUser, "ROLE_ADMIN") && !hasRole(currentUser, "ROLE_DRIVER") && (
                   <NavDropdown title="Shifts" id="appnavbar-shift-dropdown" data-testid="appnavbar-shift-dropdown" >
                     <NavDropdown.Item data-testid="appnavbar-shift-dropdown-shifts" as={Link} to="/shift/">Shifts</NavDropdown.Item>
                   </NavDropdown>

--- a/frontend/src/main/components/Scheduler/SchedulerEvent.js
+++ b/frontend/src/main/components/Scheduler/SchedulerEvent.js
@@ -2,14 +2,15 @@ import React, { useEffect, useState } from "react";
 import { ButtonGroup, Card, OverlayTrigger, Popover, Button } from 'react-bootstrap';
 
 export default function SchedulerEvents({ event, eventColor, borderColor }) {
-    const [style, setStyle] = useState({
-        event: {},
-        title: {},
-        height: 0,
-    });
+    const [style, setStyle] = useState({});
 
+    const testId = "SchedulerEvent";
+
+    // Stryker disable all : hard to test for pixel offsets
     const startOffset = 94;
+    // Stryker restore all
 
+    // Stryker disable all : hard to test for style calculations
     const convertTimeToMinutes = (time) => {
         const [timePart, modifier] = [time.slice(0, -2), time.slice(-2)];
         let [hours, minutes] = timePart.split(':').map(Number);
@@ -22,8 +23,9 @@ export default function SchedulerEvents({ event, eventColor, borderColor }) {
 
         return hours * 60 + minutes;
     };
+    // Stryker restore all
 
-    // Stryker disable all
+    // Stryker disable all : hard to test for query caching
     useEffect(() => {
         const startMinutes = convertTimeToMinutes(event.startTime);
         const endMinutes = convertTimeToMinutes(event.endTime);
@@ -51,6 +53,9 @@ export default function SchedulerEvents({ event, eventColor, borderColor }) {
                 textAlign: 'left',
                 margin: '0',
             },
+            padding5: {
+                padding: '5px',
+            },
             height: height,
         });
     }, [event.startTime, event.endTime, eventColor, borderColor]);
@@ -66,7 +71,7 @@ export default function SchedulerEvents({ event, eventColor, borderColor }) {
                 <Popover>
                     <Popover.Header as="h3">{event.title}</Popover.Header>
                     <Popover.Body>
-                        <p>
+                        <p data-testid={`${testId}-description`}>
                             {event.startTime} - {event.endTime}<br/>
                             {event.description}
                         </p>
@@ -79,10 +84,14 @@ export default function SchedulerEvents({ event, eventColor, borderColor }) {
                 </Popover>
             }
         >
-            <Card key={event.title} style={style.event}>
-                <Card.Body style={{ padding: '5px' }}>
-                    {style.height >= 20 && <Card.Text style={style.title}>{event.title}</Card.Text>}
-                    {style.height >= 40 && <Card.Text style={{ fontSize: '12px', textAlign: 'left' }}>{event.startTime} - {event.endTime}</Card.Text>}
+            <Card key={event.title} style={style.event} data-testid={testId}>
+                <Card.Body style={style.padding5}>
+                    {style.height >= 20 && <Card.Text data-testid={`${testId}-title`} style={style.title}>{event.title}</Card.Text>}
+                    {style.height >= 40 && 
+                        // Stryker disable all : hard to test for style
+                        <Card.Text data-testid={`${testId}-time`} style={{ fontSize: '12px', textAlign: 'left' }}>{event.startTime} - {event.endTime}</Card.Text>
+                        // Stryker restore all
+                    }
                 </Card.Body>
             </Card>
         </OverlayTrigger>

--- a/frontend/src/main/components/Scheduler/SchedulerEvent.js
+++ b/frontend/src/main/components/Scheduler/SchedulerEvent.js
@@ -78,7 +78,7 @@ export default function SchedulerEvents({ event, eventColor, borderColor }) {
                 </Popover>
             }
         >
-            <Card key={event.title} style={style.event} data-testid={testId}>
+            <Card key={event.title} style={style.event} data-testid={`${testId}-${event.id}`}>
                 <Card.Body style={style.padding5}>
                     {style.height >= 20 && <Card.Text data-testid={`${testId}-title`} style={style.title}>{event.title}</Card.Text>}
                     {style.height >= 40 && <Card.Text data-testid={`${testId}-time`} style={{ fontSize: '12px', textAlign: 'left' }}>{event.startTime} - {event.endTime}</Card.Text>}

--- a/frontend/src/main/components/Scheduler/SchedulerEvent.js
+++ b/frontend/src/main/components/Scheduler/SchedulerEvent.js
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from "react";
+import { ButtonGroup, Card, OverlayTrigger, Popover, Button } from 'react-bootstrap';
+
+export default function SchedulerEvents({ event, eventColor, borderColor }) {
+    const [style, setStyle] = useState({
+        event: {},
+        title: {},
+        height: 0,
+    });
+
+    const startOffset = 94;
+
+    const convertTimeToMinutes = (time) => {
+        const [timePart, modifier] = [time.slice(0, -2), time.slice(-2)];
+        let [hours, minutes] = timePart.split(':').map(Number);
+
+        if (modifier === 'PM' && hours !== 12) {
+            hours += 12;
+        } else if (modifier === 'AM' && hours === 12) {
+            hours = 0;
+        }
+
+        return hours * 60 + minutes;
+    };
+
+    // Stryker disable all
+    useEffect(() => {
+        const startMinutes = convertTimeToMinutes(event.startTime);
+        const endMinutes = convertTimeToMinutes(event.endTime);
+        const height = endMinutes - startMinutes;
+        const topPosition = startMinutes + startOffset;
+
+        setStyle({
+            event: {
+                position: 'absolute',
+                top: `${topPosition}px`,
+                height: `${height}px`,
+                width: '100%',
+                backgroundColor: eventColor,
+                border: `2px solid ${borderColor}`,
+                zIndex: 1,
+                padding: '2px',
+                justifyContent: 'center',
+                alignItems: 'left',
+            },
+            title: {
+                fontSize: height < 25 ? '10px' : height < 40 ? '12px' : height < 60 ? '14px' : '16px',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+                textAlign: 'left',
+                margin: '0',
+            },
+            height: height,
+        });
+    }, [event.startTime, event.endTime, eventColor, borderColor]);
+    // Stryker restore all
+
+    return (
+        <OverlayTrigger
+            trigger="click"
+            key={event.title}
+            placement="auto-start"
+            rootClose
+            overlay={
+                <Popover>
+                    <Popover.Header as="h3">{event.title}</Popover.Header>
+                    <Popover.Body>
+                        <p>
+                            {event.startTime} - {event.endTime}<br/>
+                            {event.description}
+                        </p>
+                        {event.actions && event.actions.map((action, index) => (
+                            <ButtonGroup key={index}>
+                                <Button variant={action.variant} onClick={action.callback}>{action.text}</Button>
+                            </ButtonGroup>
+                        ))}
+                    </Popover.Body>
+                </Popover>
+            }
+        >
+            <Card key={event.title} style={style.event}>
+                <Card.Body style={{ padding: '5px' }}>
+                    {style.height >= 20 && <Card.Text style={style.title}>{event.title}</Card.Text>}
+                    {style.height >= 40 && <Card.Text style={{ fontSize: '12px', textAlign: 'left' }}>{event.startTime} - {event.endTime}</Card.Text>}
+                </Card.Body>
+            </Card>
+        </OverlayTrigger>
+    );
+}

--- a/frontend/src/main/components/Scheduler/SchedulerEvent.js
+++ b/frontend/src/main/components/Scheduler/SchedulerEvent.js
@@ -6,11 +6,6 @@ export default function SchedulerEvents({ event, eventColor, borderColor }) {
 
     const testId = "SchedulerEvent";
 
-    // Stryker disable all : hard to test for pixel offsets
-    const startOffset = 94;
-    // Stryker restore all
-
-    // Stryker disable all : hard to test for style calculations
     const convertTimeToMinutes = (time) => {
         const [timePart, modifier] = [time.slice(0, -2), time.slice(-2)];
         let [hours, minutes] = timePart.split(':').map(Number);
@@ -23,14 +18,13 @@ export default function SchedulerEvents({ event, eventColor, borderColor }) {
 
         return hours * 60 + minutes;
     };
-    // Stryker restore all
 
-    // Stryker disable all : hard to test for query caching
+    // Stryker disable all : hard to test for specfic styles
     useEffect(() => {
         const startMinutes = convertTimeToMinutes(event.startTime);
         const endMinutes = convertTimeToMinutes(event.endTime);
         const height = endMinutes - startMinutes;
-        const topPosition = startMinutes + startOffset;
+        const topPosition = startMinutes + 94;
 
         setStyle({
             event: {
@@ -87,11 +81,7 @@ export default function SchedulerEvents({ event, eventColor, borderColor }) {
             <Card key={event.title} style={style.event} data-testid={testId}>
                 <Card.Body style={style.padding5}>
                     {style.height >= 20 && <Card.Text data-testid={`${testId}-title`} style={style.title}>{event.title}</Card.Text>}
-                    {style.height >= 40 && 
-                        // Stryker disable all : hard to test for style
-                        <Card.Text data-testid={`${testId}-time`} style={{ fontSize: '12px', textAlign: 'left' }}>{event.startTime} - {event.endTime}</Card.Text>
-                        // Stryker restore all
-                    }
+                    {style.height >= 40 && <Card.Text data-testid={`${testId}-time`} style={{ fontSize: '12px', textAlign: 'left' }}>{event.startTime} - {event.endTime}</Card.Text>}
                 </Card.Body>
             </Card>
         </OverlayTrigger>

--- a/frontend/src/main/components/Scheduler/SchedulerPanel.js
+++ b/frontend/src/main/components/Scheduler/SchedulerPanel.js
@@ -11,30 +11,33 @@ const hours = [
     '7 PM', '8 PM', '9 PM', '10 PM', '11 PM'
 ];
 
-// min required data for event object
-//     {
-//         title: "Meeting with Team",
-//         day: "Tuesday",
-//         startTime: "2:00PM",
-//         endTime: "4:00PM"
-//     }
+// Example minimum required data for event object
+// {
+//     title: "Meeting with Team",
+//     day: "Tuesday",
+//     startTime: "2:00PM",
+//     endTime: "4:00PM"
+// }
 
+// Stryker disable next-line all : no need to test default colors
 export default function SchedulerPanel({ Events = [], eventColor="#d1ecf188", borderColor="#bee5eb"}) {
+
+    const testId = "SchedulerPanel";
 
     return (
         <Container fluid style={styles.schedulerPanel}>
             <Row style={styles.headerRow}>
                 <Col style={styles.timeColumn}></Col>
                 {daysOfWeek.map(day => (
-                    <Col key={day} style={styles.dayColumn}>
+                    <Col key={day} style={styles.dayColumn} data-testid={`${testId}-${day}-column`}>
                         <Card style={styles.dayCard}>
                             <Card.Body>
-                                <Card.Title style={styles.dayTitle}>{day}</Card.Title>
+                                <Card.Title style={styles.dayTitle} data-testid={`${testId}-${day}-title`}>{day}</Card.Title>
                             </Card.Body>
                             {Events
                                 .filter(event => event.day === day)
                                 .map(event => (
-                                <SchedulerEvents key={event.id} event={event} eventColor={eventColor} borderColor={borderColor} />
+                                <SchedulerEvents key={event.id} event={event} eventColor={eventColor} borderColor={borderColor}/>
                             ))}
                         </Card>
                     </Col>
@@ -42,18 +45,21 @@ export default function SchedulerPanel({ Events = [], eventColor="#d1ecf188", bo
             </Row>
             <Row>
                 <Col style={styles.timeColumn}>
-                    <div style={{...styles.timeSlot, height: "30px", border: "0"}}></div>
+                    {/* Stryker disable next-line all : no test needed for styling */
+                    <div style={{...styles.timeSlot, height: "30px", border: "0"}}></div>}
                     {hours.map((hour, index) => (
-                        <div key={index} style={{...styles.timeSlot, border: "0"}}>
-                            <span style={styles.hourLabel}>{hour}</span>
+                        /* Stryker disable next-line all : no test needed for styling */
+                        <div key={index} style={{...styles.timeSlot, border: "0"}} data-testid={`${testId}-${hour.replace(' ', '-')}-title`}>
+                            <span style={styles.hourLabel} data-testid={`${testId}-${hour.replace(' ', '-')}-label`}>{hour}</span>
                         </div>
                     ))}
                 </Col>
                 {daysOfWeek.map(day => (
                     <Col key={day} style={styles.dayColumn}>
-                        <div style={{...styles.timeSlot, height: "30px"}}></div>
+                        {/* Stryker disable next-line all : no test needed for styling */
+                        <div style={{...styles.timeSlot, height: "30px"}}></div>}
                         {hours.slice(0, hours.length-1).map(hour => (
-                            <div key={hour} style={styles.timeSlot}>
+                            <div key={hour} style={styles.timeSlot} data-testid={`${testId}-base-slot`}>
                                 <Card style={styles.eventCard}/>
                             </div>
                         ))}
@@ -64,6 +70,7 @@ export default function SchedulerPanel({ Events = [], eventColor="#d1ecf188", bo
     );
 }
 
+// Stryker disable all: no need to test styles
 const styles = {
     schedulerPanel: {
         backgroundColor: "#fff",
@@ -115,3 +122,4 @@ const styles = {
         transform: "translateY(-50%)",
     }
 };
+// Stryker restore all

--- a/frontend/src/main/components/Scheduler/SchedulerPanel.js
+++ b/frontend/src/main/components/Scheduler/SchedulerPanel.js
@@ -1,0 +1,117 @@
+import React from "react";
+import { Container, Row, Col, Card } from 'react-bootstrap';
+import SchedulerEvents from "./SchedulerEvent";
+
+const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+const hours = [
+    '', '1 AM', '2 AM', '3 AM', '4 AM', '5 AM', '6 AM', 
+    '7 AM', '8 AM', '9 AM', '10 AM', '11 AM', '12 PM', 
+    '1 PM', '2 PM', '3 PM', '4 PM', '5 PM', '6 PM', 
+    '7 PM', '8 PM', '9 PM', '10 PM', '11 PM'
+];
+
+// min required data for event object
+//     {
+//         title: "Meeting with Team",
+//         day: "Tuesday",
+//         startTime: "2:00PM",
+//         endTime: "4:00PM"
+//     }
+
+export default function SchedulerPanel({ Events = [], eventColor="#d1ecf188", borderColor="#bee5eb"}) {
+
+    return (
+        <Container fluid style={styles.schedulerPanel}>
+            <Row style={styles.headerRow}>
+                <Col style={styles.timeColumn}></Col>
+                {daysOfWeek.map(day => (
+                    <Col key={day} style={styles.dayColumn}>
+                        <Card style={styles.dayCard}>
+                            <Card.Body>
+                                <Card.Title style={styles.dayTitle}>{day}</Card.Title>
+                            </Card.Body>
+                            {Events
+                                .filter(event => event.day === day)
+                                .map(event => (
+                                <SchedulerEvents key={event.id} event={event} eventColor={eventColor} borderColor={borderColor} />
+                            ))}
+                        </Card>
+                    </Col>
+                ))}
+            </Row>
+            <Row>
+                <Col style={styles.timeColumn}>
+                    <div style={{...styles.timeSlot, height: "30px", border: "0"}}></div>
+                    {hours.map((hour, index) => (
+                        <div key={index} style={{...styles.timeSlot, border: "0"}}>
+                            <span style={styles.hourLabel}>{hour}</span>
+                        </div>
+                    ))}
+                </Col>
+                {daysOfWeek.map(day => (
+                    <Col key={day} style={styles.dayColumn}>
+                        <div style={{...styles.timeSlot, height: "30px"}}></div>
+                        {hours.slice(0, hours.length-1).map(hour => (
+                            <div key={hour} style={styles.timeSlot}>
+                                <Card style={styles.eventCard}/>
+                            </div>
+                        ))}
+                    </Col>
+                ))}
+            </Row>
+        </Container>
+    );
+}
+
+const styles = {
+    schedulerPanel: {
+        backgroundColor: "#fff",
+        padding: "20px",
+    },
+    headerRow: {
+        textAlign: "center",
+    },
+    timeColumn: {
+        textAlign: "right",
+        borderRight: "1px solid #ddd",
+        position: "relative",
+    },
+    dayColumn: {
+        padding: 0,
+        borderRight: "1px solid #ddd"
+    },
+    dayCard: {
+        backgroundColor: "#ddd",
+        borderRadius: "0"
+    },
+    dayTitle: {
+        fontSize: "1.2rem",
+        fontWeight: "bold"
+    },
+    timeSlot: {
+        height: "60px", /* Full time slot height */
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        position: "relative",
+        borderBottom: "1px solid #ddd",
+    },
+    eventCard: {
+        width: "100%",
+        height: "100%",
+        border: "0",
+        // borderBottom: "1px solid #eeeeee",
+        borderRadius: "0",
+    },
+    hourLabel: {
+        height: "30px", /* Half of the full time slot height */
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "right",
+        position: "absolute",
+        top: 0,
+        right: "5px",
+        transform: "translateY(-50%)",
+    }
+};

--- a/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
@@ -14,7 +14,7 @@ export default function DriverAvailabilityIndexPage() {
         useBackend(
             // Stryker disable all : hard to test for query caching
             ["/api/driverAvailability"],
-            { method: "GET", url: "/api/driverAvailability/" },
+            { method: "GET", url: "/api/driverAvailability" },
             []
             // Stryker restore all 
         );

--- a/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPageAdmin.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPageAdmin.js
@@ -13,7 +13,7 @@ export default function DriverAvailabilityIndexPage() {
     const { data: availabilities, error: _error, status: _status } =
         useBackend(
             // Stryker disable all : hard to test for query caching
-            ["/api/driverAvailability"],
+            ["/api/driverAvailability/admin/all"],
             { method: "GET", url: "/api/driverAvailability/admin/all" },
             []
             // Stryker restore all 

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
@@ -8,14 +8,12 @@ import RiderApplicationTable from "main/components/RiderApplication/RiderApplica
 export default function RiderApplicationIndexPage() {
 
     const currentUser = useCurrentUser();
-    // Stryker disable all
-    // Stryker restore all 
     
     const { data: riderApplications, error: _error, status: _status } =
         useBackend(
             // Stryker disable all : hard to test for query caching
-            ["/api/rider"],
-            { method: "GET", url: "/api/rider" },
+            ["/api/rider/admin/all"],
+            { method: "GET", url: "/api/rider/admin/all" },
             []
             // Stryker restore all 
     ); 

--- a/frontend/src/main/pages/Scheduler/SchedulerPage.js
+++ b/frontend/src/main/pages/Scheduler/SchedulerPage.js
@@ -15,6 +15,8 @@ import { cellToAxiosParamsDelete as driverAvailabilityCellToAxiosParamsDelete, o
 export default function SchedulerPage() {
     const { page } = useParams();
 
+    const testId = "SchedulerPage";
+
     const navigate = useNavigate();
 
     const [events, setEvents] = useState();
@@ -115,15 +117,13 @@ export default function SchedulerPage() {
     // Stryker disable next-line all : TODO try to make a good test for this
     const deleteDriverCallback = async (driver) => { DriverDeleteMutation.mutate({row: {values: {id: driver.id}}}); }
 
-
-
-    // Stryker disable all : hard to test for use effect
-    useEffect(() => {
+    function onUpdateEvents(){
         if(page === "shifts") {
             if(shifts === undefined) return;
             setEvents(shifts.map(shift => ({
                 id: shift.id,
                 title: `Shift for Driver ${shift.driverID}`,
+                // Stryker disable next-line all : hard to test for specific description
                 description: `Backup Driver: ${shift.driverBackupID}`,
                 day: shift.day,
                 startTime: shift.shiftStart,
@@ -132,7 +132,7 @@ export default function SchedulerPage() {
                     { text: "Edit", variant: "primary", callback: () => editShiftCallback(shift) },
                     { text: "Delete", variant: "danger", callback: () => {deleteShiftCallback(shift); navigate(0)} },
                     { text: "Info", variant: "success", callback: () => infoShiftCallback(shift) }
-                ].filter(Boolean) // remove undefined values
+                ]
             })));
             setCreateLink("/shift/create");
         }
@@ -141,6 +141,7 @@ export default function SchedulerPage() {
             setEvents(ride_request.map(request => ({
                 id: request.id,
                 title: `Ride Request for ${request.student}`,
+                // Stryker disable next-line all : hard to test for specific description
                 description: `From ${request.pickupBuilding} to ${request.dropoffBuilding}`,
                 day: request.day,
                 startTime: request.startTime,
@@ -149,7 +150,7 @@ export default function SchedulerPage() {
                     { text: "Edit", variant: "primary", callback: () => editRideCallback(request) },
                     { text: "Delete", variant: "danger", callback: () => {deleteRideCallback(request); navigate(0)} },
                     { text: "Assign Driver", variant: "success", callback: () => assignRideCallback(request) }
-                ].filter(Boolean) // remove undefined values
+                ]
             })));
             setCreateLink("/ride/create");
         }
@@ -165,15 +166,16 @@ export default function SchedulerPage() {
                 actions: [  
                     { text: "Delete", variant: "danger", callback: () => {deleteDriverCallback(availability); navigate(0)} },
                     { text: "Review", variant: "success", callback: () => reviewDriverCallback(availability) }
-                ].filter(Boolean) // remove undefined values
+                ]
             })));
             setCreateLink("/availability/create");
         }
-        else {
-            setEvents();
-            setCreateLink();
-        }
-    }, [shifts, ride_request, driverAvailability, page]);
+    }
+
+    // Stryker disable all : hard to test for use effect
+    useEffect(() => {
+        onUpdateEvents();
+    }, [ shifts, ride_request, driverAvailability, page]);
     // Stryker restore all
 
     return (
@@ -184,9 +186,10 @@ export default function SchedulerPage() {
                     <Button onClick={() => {navigate('/admin/schedule/rides')}}>Ride Requests</Button>
                     <Button onClick={() => {navigate('/admin/schedule/driver')}}>Driver Availability</Button>
                 </ButtonGroup>
-                {page && 
+                {page && createLink && 
                     <Button
                         variant="success"
+                        data-testid={`${testId}-create-${page}`}
                         onClick={() => navigate(createLink)}
                     >
                         Create {page}

--- a/frontend/src/main/pages/Scheduler/SchedulerPage.js
+++ b/frontend/src/main/pages/Scheduler/SchedulerPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import SchedulerPanel from "main/components/Scheduler/SchedulerPanel";
@@ -33,16 +33,15 @@ export default function SchedulerPage() {
             },
         );
 
-    const editShiftCallback = (shift) => {
-        navigate(`/shift/edit/${shift.id}`)
-    }
+    const editShiftCallback = useCallback((shift) => {
+        navigate(`/shift/edit/${shift.id}`);
+    }, [navigate]);
 
-    const infoShiftCallback = (shift) => {
-        navigate(`/shiftInfo/${shift.id}`)
-    }
+    const infoShiftCallback = useCallback((shift) => {
+        navigate(`/shiftInfo/${shift.id}`);
+    }, [navigate]);
 
     // Stryker disable all : hard to test for query caching
-
     const shiftDeleteMutation = useBackendMutation(
         shiftCellToAxiosParamsDelete,
         { onSuccess: shiftOnDeleteSuccess },
@@ -50,8 +49,11 @@ export default function SchedulerPage() {
     );
     // Stryker restore all 
 
-    // Stryker disable next-line all : TODO try to make a good test for this
-    const deleteShiftCallback = async (shift) => { shiftDeleteMutation.mutate({row: {values: {id: shift.id}}}); }
+    // Stryker disable all : delete call back
+    const deleteShiftCallback = useCallback(async (shift) => {
+        shiftDeleteMutation.mutate({ row: { values: { id: shift.id } } });
+    }, [shiftDeleteMutation]);
+    // Stryker restore all
 
 
 
@@ -67,16 +69,15 @@ export default function SchedulerPage() {
             },
         );
 
-    const editRideCallback = (ride) => {
-        navigate(`/ride/edit/${ride.id}`)
-    }
+    const editRideCallback = useCallback((ride) => {
+        navigate(`/ride/edit/${ride.id}`);
+    }, [navigate]);
 
-    const assignRideCallback = (ride) => {
-        navigate(`/ride/assigndriver/${ride.id}`)
-    }
+    const assignRideCallback = useCallback((ride) => {
+        navigate(`/ride/assigndriver/${ride.id}`);
+    }, [navigate]);
 
     // Stryker disable all : hard to test for query caching
-
     const RideDeleteMutation = useBackendMutation(
         RideCellToAxiosParamsDelete,
         { onSuccess: RideOnDeleteSuccess },
@@ -84,8 +85,11 @@ export default function SchedulerPage() {
     );
     // Stryker restore all 
 
-    // Stryker disable next-line all : TODO try to make a good test for this
-    const deleteRideCallback = async (ride) => { RideDeleteMutation.mutate({row: {values: {id: ride.id}}}); }
+    // Stryker disable all : delete call back
+    const deleteRideCallback = useCallback(async (ride) => {
+        RideDeleteMutation.mutate({ row: { values: { id: ride.id } } });
+    }, [RideDeleteMutation]);
+    // Stryker restore all
 
 
 
@@ -101,12 +105,11 @@ export default function SchedulerPage() {
             },
         );
 
-    const reviewDriverCallback = (driver) => {
-        navigate(`/admin/availability/review/${driver.id}`)
-    }
+    const reviewDriverCallback = useCallback((driver) => {
+        navigate(`/admin/availability/review/${driver.id}`);
+    }, [navigate]);
 
     // Stryker disable all : hard to test for query caching
-
     const DriverDeleteMutation = useBackendMutation(
         driverAvailabilityCellToAxiosParamsDelete,
         { onSuccess: driverAvailabilityOnDeleteSuccess },
@@ -114,10 +117,13 @@ export default function SchedulerPage() {
     );
     // Stryker restore all 
 
-    // Stryker disable next-line all : TODO try to make a good test for this
-    const deleteDriverCallback = async (driver) => { DriverDeleteMutation.mutate({row: {values: {id: driver.id}}}); }
+    // Stryker disable all : delete call back
+    const deleteDriverCallback = useCallback(async (driver) => {
+        DriverDeleteMutation.mutate({ row: { values: { id: driver.id } } });
+    }, [DriverDeleteMutation]);
+    // Stryker restore all
 
-    function onUpdateEvents(){
+    const onUpdateEvents = useCallback(() => {
         if(page === "shifts") {
             if(shifts === undefined) return;
             setEvents(shifts.map(shift => ({
@@ -170,12 +176,12 @@ export default function SchedulerPage() {
             })));
             setCreateLink("/availability/create");
         }
-    }
+    }, [page, shifts, ride_request, driverAvailability, navigate, editShiftCallback, editRideCallback, assignRideCallback, reviewDriverCallback, deleteShiftCallback, deleteRideCallback, deleteDriverCallback, infoShiftCallback]);
 
     // Stryker disable all : hard to test for use effect
     useEffect(() => {
         onUpdateEvents();
-    }, [ shifts, ride_request, driverAvailability, page]);
+    }, [ shifts, ride_request, driverAvailability, page, onUpdateEvents ]);
     // Stryker restore all
 
     return (

--- a/frontend/src/main/pages/Scheduler/SchedulerPage.js
+++ b/frontend/src/main/pages/Scheduler/SchedulerPage.js
@@ -5,7 +5,6 @@ import SchedulerPanel from "main/components/Scheduler/SchedulerPanel";
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { Button, ButtonGroup, Stack } from "react-bootstrap";
-import { toast } from "react-toastify";
 
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { useCurrentUser , hasRole} from 'main/utils/currentUser'
@@ -15,164 +14,6 @@ import { cellToAxiosParamsDelete as RideCellToAxiosParamsDelete, onDeleteSuccess
 import { cellToAxiosParamsDelete as driverAvailabilityCellToAxiosParamsDelete, onDeleteSuccess as driverAvailabilityOnDeleteSuccess } from "main/utils/driverAvailabilityUtils"
 
 export default function SchedulerPage() {
-
-    // Function to convert a shift object to Axios parameters
-    const shiftToAxiosParams = (shift) => ({
-        url: "/api/shift/post",
-        method: "POST",
-        params: {
-            day: shift.day,
-            driverBackupID: shift.driverBackupID,
-            driverID: shift.driverID,
-            id: shift.id,
-            shiftEnd: shift.shiftEnd,
-            shiftStart: shift.shiftStart,
-        }
-    });
-
-    // Function to convert an availability object to Axios parameters
-    const driverToAxiosParams = (availability) => ({
-        url: "/api/driverAvailability/new",
-        method: "POST",
-        params: {
-            driverId: availability.driverId,
-            day: availability.day,
-            startTime: availability.startTime,
-            endTime: availability.endTime,
-            notes: availability.notes
-        }
-    });
-
-    // Function to convert a ride object to Axios parameters
-    const rideToAxiosParams = (ride) => ({
-        url: "/api/ride_request/post",
-        method: "POST",
-        params: {
-            day: ride.day,
-            startTime: ride.startTime,
-            endTime: ride.endTime,
-            pickupBuilding: ride.pickupBuilding,
-            dropoffBuilding: ride.dropoffBuilding,
-            dropoffRoom: ride.dropoffRoom,
-            pickupRoom: ride.pickupRoom,
-            course: ride.course,
-            notes: ride.notes
-        }
-    });
-
-    // Function to generate random notes of variable length
-    const generateRandomNotes = () => {
-        const possibleNotes = [
-            "Note 1", "Short note", "A bit longer note", "This is a much longer note to provide more detail",
-            "Please be on time", "Student has special requirements", "Requires assistance with luggage",
-            "Pickup location might change", "Contact student if any issues", "Prefers quiet rides"
-        ];
-        const randomIndex = Math.floor(Math.random() * possibleNotes.length);
-        return possibleNotes[randomIndex];
-    };
-
-    const onSuccessShift = (shift) => {
-        toast(`New shift Created - id: ${shift.id}, day: ${shift.day}, shiftStart: ${shift.shiftStart}, shiftEnd: ${shift.shiftEnd}, driverID: ${shift.driverID}, driverBackupID: ${shift.driverBackupID}`);
-    }
-
-    const mutationShift = useBackendMutation(
-        shiftToAxiosParams,
-        { onSuccessShift }, 
-        // Stryker disable next-line all : hard to set up test for caching
-        ["/api/shift/all"] // mutation makes this key stale so that pages relying on it reload
-        );
-
-    // Function to fill the shift database with placeholder information
-    const fillShiftDatabase = async () => {
-        const placeholderShifts = [
-            { id: 1, day: "Monday", shiftStart: "08:00AM", shiftEnd: "04:00PM", driverID: 1, driverBackupID: 1 },
-            { id: 2, day: "Tuesday", shiftStart: "09:00AM", shiftEnd: "05:00PM", driverID: 3, driverBackupID: 4 },
-            { id: 3, day: "Wednesday", shiftStart: "10:00AM", shiftEnd: "06:00PM", driverID: 5, driverBackupID: 6 },
-            { id: 4, day: "Thursday", shiftStart: "11:00AM", shiftEnd: "07:00PM", driverID: 7, driverBackupID: 8 },
-            { id: 5, day: "Friday", shiftStart: "12:00PM", shiftEnd: "08:00PM", driverID: 9, driverBackupID: 10 },
-            { id: 6, day: "Saturday", shiftStart: "01:00PM", shiftEnd: "09:00PM", driverID: 11, driverBackupID: 12 },
-            { id: 7, day: "Sunday", shiftStart: "02:00PM", shiftEnd: "10:00PM", driverID: 13, driverBackupID: 14 },
-        ];
-
-        for (const shift of placeholderShifts) {
-            try {
-                await mutationShift.mutate(shift);
-                console.log(`Shift for ${shift.day} successfully added`);
-            } catch (error) {
-                console.error(`Error adding shift for ${shift.day}: `, error);
-            }
-        }
-    };
-
-    const onSuccessDriver = (availability) => {
-        toast(`New Driver Availability Created - id: ${availability.id}`);
-    }
-
-    const mutationDriver = useBackendMutation(
-        driverToAxiosParams,
-        { onSuccessDriver },
-        // Stryker disable next-line all : hard to set up test for caching
-        ["/api/driverAvailability"]
-    );
-
-    // Function to fill the driver availability database with placeholder information
-    const fillDriverAvailabilityDatabase = async () => {
-        const placeholderAvailabilities = [
-            { id: 1, driverId: 1, day: "Monday", startTime: "03:30PM", endTime: "04:30PM", notes: generateRandomNotes() },
-            { id: 2, driverId: 1, day: "Monday", startTime: "01:30PM", endTime: "03:30PM", notes: generateRandomNotes() },
-            { id: 3, driverId: 1, day: "Tuesday", startTime: "03:40PM", endTime: "03:40PM", notes: generateRandomNotes() },
-            { id: 4, driverId: 1, day: "Wednesday", startTime: "3:30AM", endTime: "3:30AM", notes: generateRandomNotes() },
-            { id: 5, driverId: 1, day: "Thursday", startTime: "4:00PM", endTime: "8:00PM", notes: generateRandomNotes() },
-            { id: 6, driverId: 1, day: "Friday", startTime: "1:00PM", endTime: "5:00PM", notes: generateRandomNotes() },
-            { id: 7, driverId: 1, day: "Saturday", startTime: "2:00PM", endTime: "6:00PM", notes: generateRandomNotes() },
-        ];
-
-        for (const availability of placeholderAvailabilities) {
-            try {
-                await mutationDriver.mutate(availability);
-                console.log(`Availability for Driver ${availability.driverId} on ${availability.day} successfully added`);
-            } catch (error) {
-                console.error(`Error adding availability for Driver ${availability.driverId} on ${availability.day}: `, error);
-            }
-        }
-    };
-
-    const onSuccessRide = (ride) => {
-        toast(`New Ride Created - id: ${ride.id}`);
-    }
-
-    const mutationRide = useBackendMutation(
-        rideToAxiosParams,
-        { onSuccessRide },
-        // Stryker disable next-line all : hard to set up test for caching
-        ["/api/ride_request/all"]
-    );
-
-    // Function to fill the ride request database with placeholder information
-    const fillRideRequestDatabase = async () => {
-        const placeholderRides = [
-            { id: 1, riderId: 1, student: "Gen Tamada", day: "Tuesday", startTime: "3:30AM", endTime: "4:00AM", pickupBuilding: "Building A", dropoffBuilding: "Building B", dropoffRoom: "Room 101", pickupRoom: "Room 201", notes: generateRandomNotes(), course: "Course A", shiftId: 3 },
-            { id: 2, riderId: 1, student: "Alex Johnson", day: "Wednesday", startTime: "4:00AM", endTime: "4:30AM", pickupBuilding: "Building C", dropoffBuilding: "Building D", dropoffRoom: "Room 102", pickupRoom: "Room 202", notes: generateRandomNotes(), course: "Course B", shiftId: 4 },
-            { id: 3, riderId: 1, student: "Maria Garcia", day: "Thursday", startTime: "5:00AM", endTime: "5:30AM", pickupBuilding: "Building E", dropoffBuilding: "Building F", dropoffRoom: "Room 103", pickupRoom: "Room 203", notes: generateRandomNotes(), course: "Course C", shiftId: 5 },
-            { id: 4, riderId: 1, student: "James Smith", day: "Friday", startTime: "6:00AM", endTime: "6:30AM", pickupBuilding: "Building G", dropoffBuilding: "Building H", dropoffRoom: "Room 104", pickupRoom: "Room 204", notes: generateRandomNotes(), course: "Course D", shiftId: 6 },
-            { id: 5, riderId: 1, student: "Emily Davis", day: "Saturday", startTime: "7:00AM", endTime: "7:30AM", pickupBuilding: "Building I", dropoffBuilding: "Building J", dropoffRoom: "Room 105", pickupRoom: "Room 205", notes: generateRandomNotes(), course: "Course E", shiftId: 7 },
-            { id: 6, riderId: 1, student: "Daniel Brown", day: "Sunday", startTime: "8:00AM", endTime: "8:30AM", pickupBuilding: "Building K", dropoffBuilding: "Building L", dropoffRoom: "Room 106", pickupRoom: "Room 206", notes: generateRandomNotes(), course: "Course F", shiftId: 8 },
-            { id: 7, riderId: 1, student: "Sarah Wilson", day: "Monday", startTime: "9:00AM", endTime: "9:30AM", pickupBuilding: "Building M", dropoffBuilding: "Building N", dropoffRoom: "Room 107", pickupRoom: "Room 207", notes: generateRandomNotes(), course: "Course G", shiftId: 9 },
-        ];
-
-        for (const ride of placeholderRides) {
-            try {
-                await mutationRide.mutate(ride);
-                console.log(`Ride request for ${ride.student} on ${ride.day} successfully added`);
-            } catch (error) {
-                console.error(`Error adding ride request for ${ride.student} on ${ride.day}: `, error);
-            }
-        }
-    };
-
-
-
-
     const { page } = useParams();
 
     const navigate = useNavigate();
@@ -290,9 +131,9 @@ export default function SchedulerPage() {
                 startTime: shift.shiftStart,
                 endTime: shift.shiftEnd,
                 actions: [
-                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Edit", variant: "primary", callback: () => editShiftCallback(shift) },
-                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Delete", variant: "danger", callback: () => {deleteShiftCallback(shift); navigate(0)} },
-                    (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_DRIVER")) && { text: "Info", variant: "success", callback: () => infoShiftCallback(shift) }
+                    { text: "Edit", variant: "primary", callback: () => editShiftCallback(shift) },
+                    { text: "Delete", variant: "danger", callback: () => {deleteShiftCallback(shift); navigate(0)} },
+                    { text: "Info", variant: "success", callback: () => infoShiftCallback(shift) }
                 ].filter(Boolean) // remove undefined values
             })));
             setCreateLink("/shift/create");
@@ -307,9 +148,9 @@ export default function SchedulerPage() {
                 startTime: request.startTime,
                 endTime: request.endTime,
                 actions: [
-                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Edit", variant: "primary", callback: () => editRideCallback(request) },
-                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Delete", variant: "danger", callback: () => {deleteRideCallback(request); navigate(0)} },
-                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Assign Driver", variant: "success", callback: () => assignRideCallback(request) }
+                    { text: "Edit", variant: "primary", callback: () => editRideCallback(request) },
+                    { text: "Delete", variant: "danger", callback: () => {deleteRideCallback(request); navigate(0)} },
+                    { text: "Assign Driver", variant: "success", callback: () => assignRideCallback(request) }
                 ].filter(Boolean) // remove undefined values
             })));
             setCreateLink("/ride/create");
@@ -324,8 +165,8 @@ export default function SchedulerPage() {
                 startTime: availability.startTime,
                 endTime: availability.endTime,
                 actions: [  
-                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Delete", variant: "danger", callback: () => {deleteDriverCallback(availability); navigate(0)} },
-                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Review", variant: "success", callback: () => reviewDriverCallback(availability) }
+                    { text: "Delete", variant: "danger", callback: () => {deleteDriverCallback(availability); navigate(0)} },
+                    { text: "Review", variant: "success", callback: () => reviewDriverCallback(availability) }
                 ].filter(Boolean) // remove undefined values
             })));
             setCreateLink("/availability/create");
@@ -342,11 +183,6 @@ export default function SchedulerPage() {
                     <Button onClick={() => {navigate('/admin/schedule/shifts')}}>Shifts</Button>
                     <Button onClick={() => {navigate('/admin/schedule/rides')}}>Ride Requests</Button>
                     <Button onClick={() => {navigate('/admin/schedule/driver')}}>Driver Availability</Button>
-                </ButtonGroup>
-                <ButtonGroup>
-                    <Button variant="danger" onClick={() => {fillShiftDatabase();}}>Fill Shifts</Button>
-                    <Button variant="danger" onClick={() => {fillRideRequestDatabase();}}>Fill Rides</Button>
-                    <Button variant="danger" onClick={() => {fillDriverAvailabilityDatabase();}}>Fill Driver Availability</Button>
                 </ButtonGroup>
                 {page && 
                     <Button

--- a/frontend/src/main/pages/Scheduler/SchedulerPage.js
+++ b/frontend/src/main/pages/Scheduler/SchedulerPage.js
@@ -17,8 +17,8 @@ export default function SchedulerPage() {
 
     const navigate = useNavigate();
 
-    const [events, setEvents] = useState([]);
-    const [createLink, setCreateLink] = useState("");
+    const [events, setEvents] = useState();
+    const [createLink, setCreateLink] = useState();
 
     const { data: shifts } =
         useBackend(
@@ -117,7 +117,7 @@ export default function SchedulerPage() {
 
 
 
-
+    // Stryker disable all : hard to test for use effect
     useEffect(() => {
         if(page === "shifts") {
             if(shifts === undefined) return;
@@ -170,9 +170,11 @@ export default function SchedulerPage() {
             setCreateLink("/availability/create");
         }
         else {
-            setEvents([]);
+            setEvents();
+            setCreateLink();
         }
     }, [shifts, ride_request, driverAvailability, page]);
+    // Stryker restore all
 
     return (
         <BasicLayout>
@@ -185,7 +187,7 @@ export default function SchedulerPage() {
                 {page && 
                     <Button
                         variant="success"
-                        href={createLink}
+                        onClick={() => navigate(createLink)}
                     >
                         Create {page}
                     </Button>

--- a/frontend/src/main/pages/Scheduler/SchedulerPage.js
+++ b/frontend/src/main/pages/Scheduler/SchedulerPage.js
@@ -1,0 +1,363 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import SchedulerPanel from "main/components/Scheduler/SchedulerPanel";
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { Button, ButtonGroup, Stack } from "react-bootstrap";
+import { toast } from "react-toastify";
+
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { useCurrentUser , hasRole} from 'main/utils/currentUser'
+
+import { cellToAxiosParamsDelete as shiftCellToAxiosParamsDelete, onDeleteSuccess as shiftOnDeleteSuccess } from "main/utils/shiftUtils"
+import { cellToAxiosParamsDelete as RideCellToAxiosParamsDelete, onDeleteSuccess as RideOnDeleteSuccess } from "main/utils/rideUtils"
+import { cellToAxiosParamsDelete as driverAvailabilityCellToAxiosParamsDelete, onDeleteSuccess as driverAvailabilityOnDeleteSuccess } from "main/utils/driverAvailabilityUtils"
+
+export default function SchedulerPage() {
+
+    // Function to convert a shift object to Axios parameters
+    const shiftToAxiosParams = (shift) => ({
+        url: "/api/shift/post",
+        method: "POST",
+        params: {
+            day: shift.day,
+            driverBackupID: shift.driverBackupID,
+            driverID: shift.driverID,
+            id: shift.id,
+            shiftEnd: shift.shiftEnd,
+            shiftStart: shift.shiftStart,
+        }
+    });
+
+    // Function to convert an availability object to Axios parameters
+    const driverToAxiosParams = (availability) => ({
+        url: "/api/driverAvailability/new",
+        method: "POST",
+        params: {
+            driverId: availability.driverId,
+            day: availability.day,
+            startTime: availability.startTime,
+            endTime: availability.endTime,
+            notes: availability.notes
+        }
+    });
+
+    // Function to convert a ride object to Axios parameters
+    const rideToAxiosParams = (ride) => ({
+        url: "/api/ride_request/post",
+        method: "POST",
+        params: {
+            day: ride.day,
+            startTime: ride.startTime,
+            endTime: ride.endTime,
+            pickupBuilding: ride.pickupBuilding,
+            dropoffBuilding: ride.dropoffBuilding,
+            dropoffRoom: ride.dropoffRoom,
+            pickupRoom: ride.pickupRoom,
+            course: ride.course,
+            notes: ride.notes
+        }
+    });
+
+    // Function to generate random notes of variable length
+    const generateRandomNotes = () => {
+        const possibleNotes = [
+            "Note 1", "Short note", "A bit longer note", "This is a much longer note to provide more detail",
+            "Please be on time", "Student has special requirements", "Requires assistance with luggage",
+            "Pickup location might change", "Contact student if any issues", "Prefers quiet rides"
+        ];
+        const randomIndex = Math.floor(Math.random() * possibleNotes.length);
+        return possibleNotes[randomIndex];
+    };
+
+    const onSuccessShift = (shift) => {
+        toast(`New shift Created - id: ${shift.id}, day: ${shift.day}, shiftStart: ${shift.shiftStart}, shiftEnd: ${shift.shiftEnd}, driverID: ${shift.driverID}, driverBackupID: ${shift.driverBackupID}`);
+    }
+
+    const mutationShift = useBackendMutation(
+        shiftToAxiosParams,
+        { onSuccessShift }, 
+        // Stryker disable next-line all : hard to set up test for caching
+        ["/api/shift/all"] // mutation makes this key stale so that pages relying on it reload
+        );
+
+    // Function to fill the shift database with placeholder information
+    const fillShiftDatabase = async () => {
+        const placeholderShifts = [
+            { id: 1, day: "Monday", shiftStart: "08:00AM", shiftEnd: "04:00PM", driverID: 1, driverBackupID: 1 },
+            { id: 2, day: "Tuesday", shiftStart: "09:00AM", shiftEnd: "05:00PM", driverID: 3, driverBackupID: 4 },
+            { id: 3, day: "Wednesday", shiftStart: "10:00AM", shiftEnd: "06:00PM", driverID: 5, driverBackupID: 6 },
+            { id: 4, day: "Thursday", shiftStart: "11:00AM", shiftEnd: "07:00PM", driverID: 7, driverBackupID: 8 },
+            { id: 5, day: "Friday", shiftStart: "12:00PM", shiftEnd: "08:00PM", driverID: 9, driverBackupID: 10 },
+            { id: 6, day: "Saturday", shiftStart: "01:00PM", shiftEnd: "09:00PM", driverID: 11, driverBackupID: 12 },
+            { id: 7, day: "Sunday", shiftStart: "02:00PM", shiftEnd: "10:00PM", driverID: 13, driverBackupID: 14 },
+        ];
+
+        for (const shift of placeholderShifts) {
+            try {
+                await mutationShift.mutate(shift);
+                console.log(`Shift for ${shift.day} successfully added`);
+            } catch (error) {
+                console.error(`Error adding shift for ${shift.day}: `, error);
+            }
+        }
+    };
+
+    const onSuccessDriver = (availability) => {
+        toast(`New Driver Availability Created - id: ${availability.id}`);
+    }
+
+    const mutationDriver = useBackendMutation(
+        driverToAxiosParams,
+        { onSuccessDriver },
+        // Stryker disable next-line all : hard to set up test for caching
+        ["/api/driverAvailability"]
+    );
+
+    // Function to fill the driver availability database with placeholder information
+    const fillDriverAvailabilityDatabase = async () => {
+        const placeholderAvailabilities = [
+            { id: 1, driverId: 1, day: "Monday", startTime: "03:30PM", endTime: "04:30PM", notes: generateRandomNotes() },
+            { id: 2, driverId: 1, day: "Monday", startTime: "01:30PM", endTime: "03:30PM", notes: generateRandomNotes() },
+            { id: 3, driverId: 1, day: "Tuesday", startTime: "03:40PM", endTime: "03:40PM", notes: generateRandomNotes() },
+            { id: 4, driverId: 1, day: "Wednesday", startTime: "3:30AM", endTime: "3:30AM", notes: generateRandomNotes() },
+            { id: 5, driverId: 1, day: "Thursday", startTime: "4:00PM", endTime: "8:00PM", notes: generateRandomNotes() },
+            { id: 6, driverId: 1, day: "Friday", startTime: "1:00PM", endTime: "5:00PM", notes: generateRandomNotes() },
+            { id: 7, driverId: 1, day: "Saturday", startTime: "2:00PM", endTime: "6:00PM", notes: generateRandomNotes() },
+        ];
+
+        for (const availability of placeholderAvailabilities) {
+            try {
+                await mutationDriver.mutate(availability);
+                console.log(`Availability for Driver ${availability.driverId} on ${availability.day} successfully added`);
+            } catch (error) {
+                console.error(`Error adding availability for Driver ${availability.driverId} on ${availability.day}: `, error);
+            }
+        }
+    };
+
+    const onSuccessRide = (ride) => {
+        toast(`New Ride Created - id: ${ride.id}`);
+    }
+
+    const mutationRide = useBackendMutation(
+        rideToAxiosParams,
+        { onSuccessRide },
+        // Stryker disable next-line all : hard to set up test for caching
+        ["/api/ride_request/all"]
+    );
+
+    // Function to fill the ride request database with placeholder information
+    const fillRideRequestDatabase = async () => {
+        const placeholderRides = [
+            { id: 1, riderId: 1, student: "Gen Tamada", day: "Tuesday", startTime: "3:30AM", endTime: "4:00AM", pickupBuilding: "Building A", dropoffBuilding: "Building B", dropoffRoom: "Room 101", pickupRoom: "Room 201", notes: generateRandomNotes(), course: "Course A", shiftId: 3 },
+            { id: 2, riderId: 1, student: "Alex Johnson", day: "Wednesday", startTime: "4:00AM", endTime: "4:30AM", pickupBuilding: "Building C", dropoffBuilding: "Building D", dropoffRoom: "Room 102", pickupRoom: "Room 202", notes: generateRandomNotes(), course: "Course B", shiftId: 4 },
+            { id: 3, riderId: 1, student: "Maria Garcia", day: "Thursday", startTime: "5:00AM", endTime: "5:30AM", pickupBuilding: "Building E", dropoffBuilding: "Building F", dropoffRoom: "Room 103", pickupRoom: "Room 203", notes: generateRandomNotes(), course: "Course C", shiftId: 5 },
+            { id: 4, riderId: 1, student: "James Smith", day: "Friday", startTime: "6:00AM", endTime: "6:30AM", pickupBuilding: "Building G", dropoffBuilding: "Building H", dropoffRoom: "Room 104", pickupRoom: "Room 204", notes: generateRandomNotes(), course: "Course D", shiftId: 6 },
+            { id: 5, riderId: 1, student: "Emily Davis", day: "Saturday", startTime: "7:00AM", endTime: "7:30AM", pickupBuilding: "Building I", dropoffBuilding: "Building J", dropoffRoom: "Room 105", pickupRoom: "Room 205", notes: generateRandomNotes(), course: "Course E", shiftId: 7 },
+            { id: 6, riderId: 1, student: "Daniel Brown", day: "Sunday", startTime: "8:00AM", endTime: "8:30AM", pickupBuilding: "Building K", dropoffBuilding: "Building L", dropoffRoom: "Room 106", pickupRoom: "Room 206", notes: generateRandomNotes(), course: "Course F", shiftId: 8 },
+            { id: 7, riderId: 1, student: "Sarah Wilson", day: "Monday", startTime: "9:00AM", endTime: "9:30AM", pickupBuilding: "Building M", dropoffBuilding: "Building N", dropoffRoom: "Room 107", pickupRoom: "Room 207", notes: generateRandomNotes(), course: "Course G", shiftId: 9 },
+        ];
+
+        for (const ride of placeholderRides) {
+            try {
+                await mutationRide.mutate(ride);
+                console.log(`Ride request for ${ride.student} on ${ride.day} successfully added`);
+            } catch (error) {
+                console.error(`Error adding ride request for ${ride.student} on ${ride.day}: `, error);
+            }
+        }
+    };
+
+
+
+
+    const { page } = useParams();
+
+    const navigate = useNavigate();
+    const currentUser = useCurrentUser();
+
+    const [events, setEvents] = useState([]);
+    const [createLink, setCreateLink] = useState("");
+
+    const { data: shifts } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/shift/all`],
+            {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+                method: "GET",
+                url: `/api/shift/all`
+                // Stryker restore all
+            },
+        );
+
+    const editShiftCallback = (shift) => {
+        navigate(`/shift/edit/${shift.id}`)
+    }
+
+    const infoShiftCallback = (shift) => {
+        navigate(`/shiftInfo/${shift.id}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const shiftDeleteMutation = useBackendMutation(
+        shiftCellToAxiosParamsDelete,
+        { onSuccess: shiftOnDeleteSuccess },
+        ["/api/shift/all"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteShiftCallback = async (shift) => { shiftDeleteMutation.mutate({row: {values: {id: shift.id}}}); }
+
+
+
+
+    const { data: ride_request } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/ride_request/all`],
+            {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+                method: "GET",
+                url: `/api/ride_request/all`
+                // Stryker restore all
+            },
+        );
+
+    const editRideCallback = (ride) => {
+        navigate(`/ride/edit/${ride.id}`)
+    }
+
+    const assignRideCallback = (ride) => {
+        navigate(`/ride/assigndriver/${ride.id}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const RideDeleteMutation = useBackendMutation(
+        RideCellToAxiosParamsDelete,
+        { onSuccess: RideOnDeleteSuccess },
+        ["/api/ride_request/all"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteRideCallback = async (ride) => { RideDeleteMutation.mutate({row: {values: {id: ride.id}}}); }
+
+
+
+
+    const { data: driverAvailability } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/driverAvailability/admin/all`],
+            {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+                method: "GET",
+                url: `/api/driverAvailability/admin/all`
+                // Stryker restore all
+            },
+        );
+
+    const reviewDriverCallback = (driver) => {
+        navigate(`/admin/availability/review/${driver.id}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const DriverDeleteMutation = useBackendMutation(
+        driverAvailabilityCellToAxiosParamsDelete,
+        { onSuccess: driverAvailabilityOnDeleteSuccess },
+        ["/availability"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteDriverCallback = async (driver) => { DriverDeleteMutation.mutate({row: {values: {id: driver.id}}}); }
+
+
+
+
+    useEffect(() => {
+        if(page === "shifts") {
+            if(shifts === undefined) return;
+            setEvents(shifts.map(shift => ({
+                id: shift.id,
+                title: `Shift for Driver ${shift.driverID}`,
+                description: `Backup Driver: ${shift.driverBackupID}`,
+                day: shift.day,
+                startTime: shift.shiftStart,
+                endTime: shift.shiftEnd,
+                actions: [
+                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Edit", variant: "primary", callback: () => editShiftCallback(shift) },
+                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Delete", variant: "danger", callback: () => {deleteShiftCallback(shift); navigate(0)} },
+                    (hasRole(currentUser, "ROLE_ADMIN") || hasRole(currentUser, "ROLE_DRIVER")) && { text: "Info", variant: "success", callback: () => infoShiftCallback(shift) }
+                ].filter(Boolean) // remove undefined values
+            })));
+            setCreateLink("/shift/create");
+        }
+        else if(page === "rides") {
+            if(ride_request === undefined) return;
+            setEvents(ride_request.map(request => ({
+                id: request.id,
+                title: `Ride Request for ${request.student}`,
+                description: `From ${request.pickupBuilding} to ${request.dropoffBuilding}`,
+                day: request.day,
+                startTime: request.startTime,
+                endTime: request.endTime,
+                actions: [
+                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Edit", variant: "primary", callback: () => editRideCallback(request) },
+                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Delete", variant: "danger", callback: () => {deleteRideCallback(request); navigate(0)} },
+                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Assign Driver", variant: "success", callback: () => assignRideCallback(request) }
+                ].filter(Boolean) // remove undefined values
+            })));
+            setCreateLink("/ride/create");
+        }
+        else if(page === "driver") {
+            if(driverAvailability === undefined) return;
+            setEvents(driverAvailability.map(availability => ({
+                id: availability.id,
+                title: `Availability for Driver ${availability.driverId}`,
+                description: availability.notes,
+                day: availability.day,
+                startTime: availability.startTime,
+                endTime: availability.endTime,
+                actions: [  
+                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Delete", variant: "danger", callback: () => {deleteDriverCallback(availability); navigate(0)} },
+                    hasRole(currentUser, "ROLE_ADMIN") && { text: "Review", variant: "success", callback: () => reviewDriverCallback(availability) }
+                ].filter(Boolean) // remove undefined values
+            })));
+            setCreateLink("/availability/create");
+        }
+        else {
+            setEvents([]);
+        }
+    }, [shifts, ride_request, driverAvailability, page]);
+
+    return (
+        <BasicLayout>
+            <Stack className="flex-row justify-content-between">
+                <ButtonGroup>
+                    <Button onClick={() => {navigate('/admin/schedule/shifts')}}>Shifts</Button>
+                    <Button onClick={() => {navigate('/admin/schedule/rides')}}>Ride Requests</Button>
+                    <Button onClick={() => {navigate('/admin/schedule/driver')}}>Driver Availability</Button>
+                </ButtonGroup>
+                <ButtonGroup>
+                    <Button variant="danger" onClick={() => {fillShiftDatabase();}}>Fill Shifts</Button>
+                    <Button variant="danger" onClick={() => {fillRideRequestDatabase();}}>Fill Rides</Button>
+                    <Button variant="danger" onClick={() => {fillDriverAvailabilityDatabase();}}>Fill Driver Availability</Button>
+                </ButtonGroup>
+                {page && 
+                    <Button
+                        variant="success"
+                        href={createLink}
+                    >
+                        Create {page}
+                    </Button>
+                }
+            </Stack>
+            <SchedulerPanel Events={events} />
+        </BasicLayout>
+    );
+}

--- a/frontend/src/main/pages/Scheduler/SchedulerPage.js
+++ b/frontend/src/main/pages/Scheduler/SchedulerPage.js
@@ -7,7 +7,6 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { Button, ButtonGroup, Stack } from "react-bootstrap";
 
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
-import { useCurrentUser , hasRole} from 'main/utils/currentUser'
 
 import { cellToAxiosParamsDelete as shiftCellToAxiosParamsDelete, onDeleteSuccess as shiftOnDeleteSuccess } from "main/utils/shiftUtils"
 import { cellToAxiosParamsDelete as RideCellToAxiosParamsDelete, onDeleteSuccess as RideOnDeleteSuccess } from "main/utils/rideUtils"
@@ -17,7 +16,6 @@ export default function SchedulerPage() {
     const { page } = useParams();
 
     const navigate = useNavigate();
-    const currentUser = useCurrentUser();
 
     const [events, setEvents] = useState([]);
     const [createLink, setCreateLink] = useState("");

--- a/frontend/src/main/pages/Scheduler/SchedulerPage.js
+++ b/frontend/src/main/pages/Scheduler/SchedulerPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import SchedulerPanel from "main/components/Scheduler/SchedulerPanel";
@@ -19,9 +19,6 @@ export default function SchedulerPage() {
 
     const navigate = useNavigate();
 
-    const [events, setEvents] = useState();
-    const [createLink, setCreateLink] = useState();
-
     const { data: shifts } =
         useBackend(
             // Stryker disable next-line all : don't test internal caching of React Query
@@ -33,13 +30,13 @@ export default function SchedulerPage() {
             },
         );
 
-    const editShiftCallback = useCallback((shift) => {
-        navigate(`/shift/edit/${shift.id}`);
-    }, [navigate]);
+    const editShiftCallback = (shift) => {
+        navigate(`/shift/edit/${shift.id}`)
+    }
 
-    const infoShiftCallback = useCallback((shift) => {
-        navigate(`/shiftInfo/${shift.id}`);
-    }, [navigate]);
+    const infoShiftCallback = (shift) => {
+        navigate(`/shiftInfo/${shift.id}`)
+    }
 
     // Stryker disable all : hard to test for query caching
     const shiftDeleteMutation = useBackendMutation(
@@ -49,11 +46,8 @@ export default function SchedulerPage() {
     );
     // Stryker restore all 
 
-    // Stryker disable all : delete call back
-    const deleteShiftCallback = useCallback(async (shift) => {
-        shiftDeleteMutation.mutate({ row: { values: { id: shift.id } } });
-    }, [shiftDeleteMutation]);
-    // Stryker restore all
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteShiftCallback = async (shift) => { shiftDeleteMutation.mutate({row: {values: {id: shift.id}}}); }
 
 
 
@@ -69,13 +63,13 @@ export default function SchedulerPage() {
             },
         );
 
-    const editRideCallback = useCallback((ride) => {
-        navigate(`/ride/edit/${ride.id}`);
-    }, [navigate]);
+    const editRideCallback = (ride) => {
+        navigate(`/ride/edit/${ride.id}`)
+    }
 
-    const assignRideCallback = useCallback((ride) => {
-        navigate(`/ride/assigndriver/${ride.id}`);
-    }, [navigate]);
+    const assignRideCallback = (ride) => {
+        navigate(`/ride/assigndriver/${ride.id}`)
+    }
 
     // Stryker disable all : hard to test for query caching
     const RideDeleteMutation = useBackendMutation(
@@ -85,11 +79,8 @@ export default function SchedulerPage() {
     );
     // Stryker restore all 
 
-    // Stryker disable all : delete call back
-    const deleteRideCallback = useCallback(async (ride) => {
-        RideDeleteMutation.mutate({ row: { values: { id: ride.id } } });
-    }, [RideDeleteMutation]);
-    // Stryker restore all
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteRideCallback = async (ride) => { RideDeleteMutation.mutate({row: {values: {id: ride.id}}}); }
 
 
 
@@ -105,9 +96,9 @@ export default function SchedulerPage() {
             },
         );
 
-    const reviewDriverCallback = useCallback((driver) => {
-        navigate(`/admin/availability/review/${driver.id}`);
-    }, [navigate]);
+    const reviewDriverCallback = (driver) => {
+        navigate(`/admin/availability/review/${driver.id}`)
+    }
 
     // Stryker disable all : hard to test for query caching
     const DriverDeleteMutation = useBackendMutation(
@@ -117,72 +108,70 @@ export default function SchedulerPage() {
     );
     // Stryker restore all 
 
-    // Stryker disable all : delete call back
-    const deleteDriverCallback = useCallback(async (driver) => {
-        DriverDeleteMutation.mutate({ row: { values: { id: driver.id } } });
-    }, [DriverDeleteMutation]);
-    // Stryker restore all
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteDriverCallback = async (driver) => { DriverDeleteMutation.mutate({row: {values: {id: driver.id}}}); }
 
-    const onUpdateEvents = useCallback(() => {
-        if(page === "shifts") {
-            if(shifts === undefined) return;
-            setEvents(shifts.map(shift => ({
-                id: shift.id,
-                title: `Shift for Driver ${shift.driverID}`,
-                // Stryker disable next-line all : hard to test for specific description
-                description: `Backup Driver: ${shift.driverBackupID}`,
-                day: shift.day,
-                startTime: shift.shiftStart,
-                endTime: shift.shiftEnd,
-                actions: [
-                    { text: "Edit", variant: "primary", callback: () => editShiftCallback(shift) },
-                    { text: "Delete", variant: "danger", callback: () => {deleteShiftCallback(shift); navigate(0)} },
-                    { text: "Info", variant: "success", callback: () => infoShiftCallback(shift) }
-                ]
-            })));
-            setCreateLink("/shift/create");
+    const eventLink = () => {
+        if(page === "shifts" && shifts !== undefined) {
+            return {
+                event: 
+                    shifts.map(shift => ({
+                        id: shift.id,
+                        title: `Shift for Driver ${shift.driverID}`,
+                        // Stryker disable next-line all : hard to test for specific description
+                        description: `Backup Driver: ${shift.driverBackupID}`,
+                        day: shift.day,
+                        startTime: shift.shiftStart,
+                        endTime: shift.shiftEnd,
+                        actions: [
+                            { text: "Edit", variant: "primary", callback: () => editShiftCallback(shift) },
+                            { text: "Delete", variant: "danger", callback: () => {deleteShiftCallback(shift); navigate(0)} },
+                            { text: "Info", variant: "success", callback: () => infoShiftCallback(shift) }
+                        ]
+                    })),
+                createLink: "/shift/create"
+            }
         }
-        else if(page === "rides") {
-            if(ride_request === undefined) return;
-            setEvents(ride_request.map(request => ({
-                id: request.id,
-                title: `Ride Request for ${request.student}`,
-                // Stryker disable next-line all : hard to test for specific description
-                description: `From ${request.pickupBuilding} to ${request.dropoffBuilding}`,
-                day: request.day,
-                startTime: request.startTime,
-                endTime: request.endTime,
-                actions: [
-                    { text: "Edit", variant: "primary", callback: () => editRideCallback(request) },
-                    { text: "Delete", variant: "danger", callback: () => {deleteRideCallback(request); navigate(0)} },
-                    { text: "Assign Driver", variant: "success", callback: () => assignRideCallback(request) }
-                ]
-            })));
-            setCreateLink("/ride/create");
+        else if(page === "rides" && ride_request !== undefined) {
+            return {
+                event:
+                    ride_request.map(request => ({
+                        id: request.id,
+                        title: `Ride Request for ${request.student}`,
+                        // Stryker disable next-line all : hard to test for specific description
+                        description: `From ${request.pickupBuilding} to ${request.dropoffBuilding}`,
+                        day: request.day,
+                        startTime: request.startTime,
+                        endTime: request.endTime,
+                        actions: [
+                            { text: "Edit", variant: "primary", callback: () => editRideCallback(request) },
+                            { text: "Delete", variant: "danger", callback: () => {deleteRideCallback(request); navigate(0)} },
+                            { text: "Assign Driver", variant: "success", callback: () => assignRideCallback(request) }
+                        ]
+                    })),
+                createLink: "/ride/create"
+            }
         }
-        else if(page === "driver") {
-            if(driverAvailability === undefined) return;
-            setEvents(driverAvailability.map(availability => ({
-                id: availability.id,
-                title: `Availability for Driver ${availability.driverId}`,
-                description: availability.notes,
-                day: availability.day,
-                startTime: availability.startTime,
-                endTime: availability.endTime,
-                actions: [  
-                    { text: "Delete", variant: "danger", callback: () => {deleteDriverCallback(availability); navigate(0)} },
-                    { text: "Review", variant: "success", callback: () => reviewDriverCallback(availability) }
-                ]
-            })));
-            setCreateLink("/availability/create");
+        else if(page === "driver" && driverAvailability !== undefined) {
+            return {
+                event:
+                    driverAvailability.map(availability => ({
+                        id: availability.id,
+                        title: `Availability for Driver ${availability.driverId}`,
+                        description: availability.notes,
+                        day: availability.day,
+                        startTime: availability.startTime,
+                        endTime: availability.endTime,
+                        actions: [  
+                            { text: "Delete", variant: "danger", callback: () => {deleteDriverCallback(availability); navigate(0)} },
+                            { text: "Review", variant: "success", callback: () => reviewDriverCallback(availability) }
+                        ]
+                    })),
+                createLink: "/availability/create"
+            }
         }
-    }, [page, shifts, ride_request, driverAvailability, navigate, editShiftCallback, editRideCallback, assignRideCallback, reviewDriverCallback, deleteShiftCallback, deleteRideCallback, deleteDriverCallback, infoShiftCallback]);
-
-    // Stryker disable all : hard to test for use effect
-    useEffect(() => {
-        onUpdateEvents();
-    }, [ shifts, ride_request, driverAvailability, page, onUpdateEvents ]);
-    // Stryker restore all
+        return {}
+    }
 
     return (
         <BasicLayout>
@@ -192,17 +181,17 @@ export default function SchedulerPage() {
                     <Button onClick={() => {navigate('/admin/schedule/rides')}}>Ride Requests</Button>
                     <Button onClick={() => {navigate('/admin/schedule/driver')}}>Driver Availability</Button>
                 </ButtonGroup>
-                {page && createLink && 
+                {page && eventLink().createLink && 
                     <Button
                         variant="success"
                         data-testid={`${testId}-create-${page}`}
-                        onClick={() => navigate(createLink)}
+                        onClick={() => navigate(eventLink().createLink)}
                     >
                         Create {page}
                     </Button>
                 }
             </Stack>
-            <SchedulerPanel Events={events} />
+            <SchedulerPanel Events={eventLink().event} />
         </BasicLayout>
     );
 }

--- a/frontend/src/stories/components/Scheduler/SchedulerEvent.stories.js
+++ b/frontend/src/stories/components/Scheduler/SchedulerEvent.stories.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import SchedulerEvent from "main/components/Scheduler/SchedulerEvent";
+import { scheduleEventsFixtures } from 'fixtures/scheduleEventsFixtures';
+
+export default {
+    title: 'components/Scheduler/SchedulerEvent',
+    component: SchedulerEvent
+};
+
+const Template = (args) => {
+    return (
+        <SchedulerEvent {...args} />
+    )
+}
+
+export const Default = Template.bind({});
+
+Default.args = {
+    event: scheduleEventsFixtures.oneEvent
+};

--- a/frontend/src/stories/components/Scheduler/SchedulerPanel.stories.js
+++ b/frontend/src/stories/components/Scheduler/SchedulerPanel.stories.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import SchedulerPanel from "main/components/Scheduler/SchedulerPanel";
+import { scheduleEventsFixtures } from 'fixtures/scheduleEventsFixtures';
+
+
+export default {
+    title: 'components/Scheduler/SchedulerPanel',
+    component: SchedulerPanel
+};
+
+const Template = (args) => {
+    return (
+        <SchedulerPanel {...args} />
+    )
+};
+
+
+export const Default = Template.bind({});
+
+export const threeEvents = Template.bind({});
+
+threeEvents.args = {
+    Events: scheduleEventsFixtures.threeEvents
+};
+
+export const sixEvents = Template.bind({});
+
+sixEvents.args = {
+    Events: scheduleEventsFixtures.sixEvents
+};

--- a/frontend/src/stories/pages/Scheduler/SchedulerPage.stories.js
+++ b/frontend/src/stories/pages/Scheduler/SchedulerPage.stories.js
@@ -2,10 +2,6 @@ import React from 'react';
 
 import SchedulerPage from 'main/pages/Scheduler/SchedulerPage';
 
-import { rideFixtures } from 'fixtures/rideFixtures';
-import { driverAvailabilityFixtures } from 'fixtures/driverAvailabilityFixtures';
-import { shiftFixtures } from 'fixtures/shiftFixtures';
-
 export default {
     title: 'pages/Scheduler/SchedulerPage',
     component: SchedulerPage

--- a/frontend/src/stories/pages/Scheduler/SchedulerPage.stories.js
+++ b/frontend/src/stories/pages/Scheduler/SchedulerPage.stories.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import SchedulerPage from 'main/pages/Scheduler/SchedulerPage';
+
+import { rideFixtures } from 'fixtures/rideFixtures';
+import { driverAvailabilityFixtures } from 'fixtures/driverAvailabilityFixtures';
+import { shiftFixtures } from 'fixtures/shiftFixtures';
+
+export default {
+    title: 'pages/Scheduler/SchedulerPage',
+    component: SchedulerPage
+};
+
+const Template = () => <SchedulerPage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/tests/components/Scheduler/SchedulePanel.test.js
+++ b/frontend/src/tests/components/Scheduler/SchedulePanel.test.js
@@ -4,39 +4,12 @@ import { within } from '@testing-library/dom'
 import { BrowserRouter as Router } from 'react-router-dom';
 
 import SchedulerPanel from 'main/components/Scheduler/SchedulerPanel';
+import { scheduleEventsFixtures } from 'fixtures/scheduleEventsFixtures';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
 describe('SchedulerPanel tests', () => {
     const queryClient = new QueryClient();
-    const events = [
-        {
-            id: 1,
-            title: 'Meeting with Bob',
-            day: 'Monday',
-            startTime: '02:00PM',
-            endTime: '03:00PM',
-            description: 'Discuss the new project milestones.',
-            actions: []
-        },
-        {
-            id: 2,
-            title: 'Lunch with Alice',
-            day: 'Wednesday',
-            startTime: '12:00PM',
-            endTime: '01:00PM',
-            description: 'Casual lunch.',
-            actions: []
-        },
-        {
-            id: 3,
-            title: 'Gym',
-            day: 'Friday',
-            startTime: '06:00AM',
-            endTime: '07:00AM',
-            description: 'Morning workout.',
-            actions: []
-        },
-    ];
+    const events = scheduleEventsFixtures.sixEvents;
 
     const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 

--- a/frontend/src/tests/components/Scheduler/SchedulePanel.test.js
+++ b/frontend/src/tests/components/Scheduler/SchedulePanel.test.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { within } from '@testing-library/dom'
+import { BrowserRouter as Router } from 'react-router-dom';
+
+import SchedulerPanel from 'main/components/Scheduler/SchedulerPanel';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+describe('SchedulerPanel tests', () => {
+    const queryClient = new QueryClient();
+    const events = [
+        {
+            id: 1,
+            title: 'Meeting with Bob',
+            day: 'Monday',
+            startTime: '02:00PM',
+            endTime: '03:00PM',
+            description: 'Discuss the new project milestones.',
+            actions: []
+        },
+        {
+            id: 2,
+            title: 'Lunch with Alice',
+            day: 'Wednesday',
+            startTime: '12:00PM',
+            endTime: '01:00PM',
+            description: 'Casual lunch.',
+            actions: []
+        },
+        {
+            id: 3,
+            title: 'Gym',
+            day: 'Friday',
+            startTime: '06:00AM',
+            endTime: '07:00AM',
+            description: 'Morning workout.',
+            actions: []
+        },
+    ];
+
+    const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+    const hours = [
+        '', '1 AM', '2 AM', '3 AM', '4 AM', '5 AM', '6 AM', 
+        '7 AM', '8 AM', '9 AM', '10 AM', '11 AM', '12 PM', 
+        '1 PM', '2 PM', '3 PM', '4 PM', '5 PM', '6 PM', 
+        '7 PM', '8 PM', '9 PM', '10 PM', '11 PM'
+    ];
+
+    test('renders without crashing', async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <SchedulerPanel />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        daysOfWeek.forEach(day => {
+            const dayTitle = screen.getByTestId(`SchedulerPanel-${day}-title`);
+            expect( dayTitle ).toBeInTheDocument();
+            const { getByText } = within(dayTitle);
+            expect(getByText(day)).toBeInTheDocument();
+        });
+
+        hours.forEach(hour => {
+            const hourSlot = screen.getByTestId(`SchedulerPanel-${hour.replace(' ', '-')}-title`);
+            expect(hourSlot).toBeInTheDocument();
+            const { getByTestId } = within(hourSlot);
+            expect(getByTestId(`SchedulerPanel-${hour.replace(' ', '-')}-label`)).toBeInTheDocument();
+        });
+
+        expect(screen.getAllByTestId('SchedulerPanel-base-slot').length).toBe(161);
+    });
+
+    test('renders events on correct days', async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <SchedulerPanel Events={events} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        events.forEach(event => {
+            expect(screen.getAllByTestId(`SchedulerEvent-${event.id}`).length).toBe(1);
+            const dayColumn = screen.getByTestId(`SchedulerPanel-${event.day}-column`);
+            expect(dayColumn).toBeInTheDocument();
+            const { getByTestId } = within(dayColumn);
+            expect(getByTestId(`SchedulerEvent-${event.id}`)).toBeInTheDocument();
+        });
+    });
+
+    test('renders without events', async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <SchedulerPanel Events={[]} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        daysOfWeek.forEach(day => {
+            expect(screen.getByText(day)).toBeInTheDocument();
+        });
+
+        hours.forEach(hour => {
+            if (hour) {
+                expect(screen.getByText(hour)).toBeInTheDocument();
+            }
+        });
+    });
+});

--- a/frontend/src/tests/components/Scheduler/SchedulerEvent.test.js
+++ b/frontend/src/tests/components/Scheduler/SchedulerEvent.test.js
@@ -1,0 +1,130 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+
+import SchedulerEvents from 'main/components/Scheduler/SchedulerEvent';
+import { scheduleEventsFixtures } from 'fixtures/scheduleEventsFixtures';
+
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+
+describe('SchedulerEvents tests', () => {
+    const queryClient = new QueryClient();
+
+    const event = {
+        ...scheduleEventsFixtures.oneEvent,
+        actions: [
+            {
+                text: 'Edit',
+                callback: jest.fn()
+            },
+            {
+                text: 'Delete',
+                callback: jest.fn()
+            }
+        ]
+    };
+
+    test('renders event with correct styles and popover', async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <SchedulerEvents 
+                        event={event}
+                        eventColor="lightblue"
+                        borderColor="blue"
+                    />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        // Check if the event is rendered with the correct title
+        expect(screen.getByText(event.title)).toBeInTheDocument();
+
+        // Check if the event card has correct styles
+        const card = screen.getByText(event.title).closest('.card');
+        expect(card).toHaveStyle('background-color: lightblue');
+        expect(card).toHaveStyle('border: 2px solid blue');
+
+        expect(screen.getByText(`${event.startTime} - ${event.endTime}`)).toBeInTheDocument();
+
+        // Simulate a click to show the popover
+        fireEvent.click(card);
+
+        // Check if the popover content is correct
+        await waitFor(() => expect(screen.getByTestId('SchedulerEvent-description')).toBeInTheDocument());
+
+        // Check if the actions are rendered correctly
+        event.actions.forEach(action => {
+            expect(screen.getByText(action.text)).toBeInTheDocument();
+        });
+
+        // Check if clicking action buttons triggers callbacks
+        event.actions.forEach(action => {
+            const button = screen.getByText(action.text);
+            fireEvent.click(button);
+            expect(action.callback).toHaveBeenCalled();
+        });
+
+    });
+
+
+    const heights = [
+        { startTime: '12:00PM', endTime: '12:10PM', expectedFontSize: null, expectedHeight: 10 },
+        { startTime: '12:00PM', endTime: '12:20PM', expectedFontSize: '10px', expectedHeight: 20 },
+        { startTime: '12:00PM', endTime: '12:30PM', expectedFontSize: '12px', expectedHeight: 30 },
+        { startTime: '12:00PM', endTime: '12:40PM', expectedFontSize: '14px', expectedHeight: 40 },
+        { startTime: '12:00PM', endTime: '01:00PM', expectedFontSize: '16px', expectedHeight: 60 },
+        { startTime: '12:00PM', endTime: '02:00PM', expectedFontSize: '16px', expectedHeight: 120 },
+        { startTime: '12:00AM', endTime: '02:00PM', expectedFontSize: '16px', expectedHeight: 840 },
+    ];
+    
+    heights.forEach(({ startTime, endTime, expectedFontSize, expectedHeight }) => {
+        test(`renders event with height from ${startTime} to ${endTime} with font size ${expectedFontSize}`, async () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <Router>
+                        <SchedulerEvents 
+                            event={{ ...event, startTime, endTime }}
+                            eventColor="lightblue"
+                            borderColor="blue"
+                        />
+                    </Router>
+                </QueryClientProvider>
+            );
+
+            // Check if the event card has correct font size
+            if(expectedFontSize === null) {
+                expect(screen.queryByTestId('SchedulerEvent-title')).not.toBeInTheDocument();
+            }
+            else {
+                const cardText = await screen.findByText(event.title);
+                expect(cardText).toHaveStyle(`font-size: ${expectedFontSize}`);
+            }
+
+            // Check if the event card has correct height
+            const card = screen.getByTestId('SchedulerEvent');
+            expect(card).toHaveStyle(`height: ${expectedHeight}px`);
+
+            if(expectedHeight >= 40) {
+                expect(screen.getByTestId('SchedulerEvent-title')).toBeInTheDocument();
+                expect(screen.getByTestId('SchedulerEvent-time')).toBeInTheDocument();
+            }
+            else if(expectedHeight >= 20) {
+                expect(screen.queryByTestId('SchedulerEvent-title')).toBeInTheDocument();
+                expect(screen.queryByTestId('SchedulerEvent-time')).not.toBeInTheDocument();
+            }
+            else {
+                expect(screen.queryByTestId('SchedulerEvent-title')).not.toBeInTheDocument();
+                expect(screen.queryByTestId('SchedulerEvent-time')).not.toBeInTheDocument();
+            }
+
+        });
+    });
+});

--- a/frontend/src/tests/components/Scheduler/SchedulerEvent.test.js
+++ b/frontend/src/tests/components/Scheduler/SchedulerEvent.test.js
@@ -110,7 +110,7 @@ describe('SchedulerEvents tests', () => {
             }
 
             // Check if the event card has correct height
-            const card = screen.getByTestId('SchedulerEvent');
+            const card = screen.getByTestId('SchedulerEvent-1');
             expect(card).toHaveStyle(`height: ${expectedHeight}px`);
 
             if(expectedHeight >= 40) {

--- a/frontend/src/tests/components/Scheduler/SchedulerEvent.test.js
+++ b/frontend/src/tests/components/Scheduler/SchedulerEvent.test.js
@@ -83,6 +83,7 @@ describe('SchedulerEvents tests', () => {
         { startTime: '12:00PM', endTime: '01:00PM', expectedFontSize: '16px', expectedHeight: 60 },
         { startTime: '12:00PM', endTime: '02:00PM', expectedFontSize: '16px', expectedHeight: 120 },
         { startTime: '12:00AM', endTime: '02:00PM', expectedFontSize: '16px', expectedHeight: 840 },
+        { startTime: '2:00AM', endTime: '02:00PM', expectedFontSize: '16px', expectedHeight: 720 },
     ];
     
     heights.forEach(({ startTime, endTime, expectedFontSize, expectedHeight }) => {
@@ -114,7 +115,11 @@ describe('SchedulerEvents tests', () => {
 
             if(expectedHeight >= 40) {
                 expect(screen.getByTestId('SchedulerEvent-title')).toBeInTheDocument();
-                expect(screen.getByTestId('SchedulerEvent-time')).toBeInTheDocument();
+                const time = screen.getByTestId('SchedulerEvent-time');
+                expect(time).toBeInTheDocument();
+                expect(time).toHaveStyle('font-size: 12px');
+                expect(time).toHaveStyle('text-align: left');
+
             }
             else if(expectedHeight >= 20) {
                 expect(screen.queryByTestId('SchedulerEvent-title')).toBeInTheDocument();

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
@@ -45,7 +45,7 @@ describe("DriverAvailabilityIndexPage tests", () => {
 
     test("fetches driverAvailabilities using the correct GET method", async () => {
         setupAdminUser();
-        axiosMock.onGet("/api/driverAvailability/").reply(config => {
+        axiosMock.onGet("/api/driverAvailability").reply(config => {
             if (config.method === "get") {  // Ensures the method is GET
                 return [200, driverAvailabilityFixtures.threeAvailability];
             }
@@ -76,7 +76,7 @@ describe("DriverAvailabilityIndexPage tests", () => {
         // This variable will help us verify that the correct method was used.
         let wasGetMethodUsed = false;
     
-        axiosMock.onAny("/api/driverAvailability/").reply(config => {
+        axiosMock.onAny("/api/driverAvailability").reply(config => {
             if (config.method === "get") {  
                 wasGetMethodUsed = true; 
                 return [200, driverAvailabilityFixtures.threeAvailability];

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
@@ -45,7 +45,7 @@ describe("RiderApplicationIndexPageAdmin tests", () => {
     test("renders without crashing for regular user", () => {
         setupMemberOnly();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/rider").reply(200, []);
+        axiosMock.onGet("/api/rider/admin/all").reply(200, []);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -60,7 +60,7 @@ describe("RiderApplicationIndexPageAdmin tests", () => {
     test("renders without crashing for admin user", () => {
         setupAdminUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/rider").reply(200, []);
+        axiosMock.onGet("/api/rider/admin/all").reply(200, []);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -74,7 +74,7 @@ describe("RiderApplicationIndexPageAdmin tests", () => {
     test("renders three rides without crashing for regular user", async () => {
         setupMemberOnly();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/rider").reply(200, riderApplicationFixtures.threeRiderApplications);
+        axiosMock.onGet("/api/rider/admin/all").reply(200, riderApplicationFixtures.threeRiderApplications);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -93,7 +93,7 @@ describe("RiderApplicationIndexPageAdmin tests", () => {
     test("renders three rides without crashing for admin user", async () => {
         setupAdminUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/rider").reply(200, riderApplicationFixtures.threeRiderApplications);
+        axiosMock.onGet("/api/rider/admin/all").reply(200, riderApplicationFixtures.threeRiderApplications);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -113,7 +113,7 @@ describe("RiderApplicationIndexPageAdmin tests", () => {
         setupMemberOnly();
 
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/rider").timeout();
+        axiosMock.onGet("/api/rider/admin/all").timeout();
 
         const restoreConsole = mockConsole();
 

--- a/frontend/src/tests/pages/Scheduler/SchedulerPage.test.js
+++ b/frontend/src/tests/pages/Scheduler/SchedulerPage.test.js
@@ -145,6 +145,24 @@ describe('SchedulerPage tests', () => {
         await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/admin/schedule/driver'));
     });
 
+    test('navigates to wrong page', async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter initialEntries={['/admin/schedule/wrong']}>
+                    <Routes>
+                        <Route path="/admin/schedule/:page" element={<SchedulerPage />} />
+                    </Routes>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.queryByTestId(`SchedulerEvent-1`)).not.toBeInTheDocument();
+        });
+
+        expect(screen.queryByTestId('SchedulerPage-create-wrong')).not.toBeInTheDocument();
+    });
+
     test('navigates to shifts and loads shift events', async () => {
         render(
             <QueryClientProvider client={queryClient}>
@@ -165,6 +183,9 @@ describe('SchedulerPage tests', () => {
 
         const createButton = screen.getByText('Create shifts');
         expect(createButton).toBeInTheDocument();
+
+        const createButton2 = screen.getByTestId('SchedulerPage-create-shifts');
+        expect(createButton2).toBeInTheDocument();
 
         fireEvent.click(createButton);
         await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/shift/create'));
@@ -241,9 +262,20 @@ describe('SchedulerPage tests', () => {
 
         await waitFor(() => {
             expect(screen.getByText('Edit')).toBeInTheDocument();
-            expect(screen.getByText('Info')).toBeInTheDocument();
-            expect(screen.getByText('Delete')).toBeInTheDocument();
         });
+
+        const editButton = screen.getByText('Edit');
+        expect(editButton).toBeInTheDocument();
+
+        const infoButton = screen.getByText('Info');
+        expect(infoButton).toBeInTheDocument();
+
+        const deleteButton = screen.getByText('Delete');
+        expect(deleteButton).toBeInTheDocument();
+
+        expect(editButton).toHaveClass('btn-primary');
+        expect(infoButton).toHaveClass('btn-success');
+        expect(deleteButton).toHaveClass('btn-danger');
 
         fireEvent.click(screen.getByText('Edit'));
         await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/shift/edit/1'));
@@ -278,8 +310,16 @@ describe('SchedulerPage tests', () => {
 
         await waitFor(() => {
             expect(screen.getByText('Review')).toBeInTheDocument();
-            expect(screen.getByText('Delete')).toBeInTheDocument();
         });
+
+        const reviewButton = screen.getByText('Review');
+        expect(reviewButton).toBeInTheDocument();
+
+        const deleteButton = screen.getByText('Delete');
+        expect(deleteButton).toBeInTheDocument();
+
+        expect(reviewButton).toHaveClass('btn-success');
+        expect(deleteButton).toHaveClass('btn-danger');
 
         fireEvent.click(screen.getByText('Review'));
         await waitFor(()=> expect(mockNavigate).toHaveBeenCalledWith(`/admin/availability/review/${driverAvailabilityFixtures.threeAvailability[0].id}`));
@@ -311,9 +351,20 @@ describe('SchedulerPage tests', () => {
 
         await waitFor(() => {
             expect(screen.getByText('Edit')).toBeInTheDocument();
-            expect(screen.getByText('Delete')).toBeInTheDocument();
-            expect(screen.getByText('Assign Driver')).toBeInTheDocument();
         });
+
+        const editButton = screen.getByText('Edit');
+        expect(editButton).toBeInTheDocument();
+
+        const deleteButton = screen.getByText('Delete');
+        expect(deleteButton).toBeInTheDocument();
+
+        const assignButton = screen.getByText('Assign Driver');
+        expect(assignButton).toBeInTheDocument();
+
+        expect(editButton).toHaveClass('btn-primary');
+        expect(deleteButton).toHaveClass('btn-danger');
+        expect(assignButton).toHaveClass('btn-success');
 
         fireEvent.click(screen.getByText('Edit'));
         await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith(`/ride/edit/${rideFixtures.threeRidesTable[0].id}`));

--- a/frontend/src/tests/pages/Scheduler/SchedulerPage.test.js
+++ b/frontend/src/tests/pages/Scheduler/SchedulerPage.test.js
@@ -1,0 +1,180 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter as Router, MemoryRouter, Route, Routes } from 'react-router-dom';
+import SchedulerPage from 'main/pages/Scheduler/SchedulerPage';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { useBackend } from 'main/utils/useBackend';
+
+const mockedNavigate = jest.fn();
+
+jest.mock('main/utils/useBackend', () => ({
+    useBackend: jest.fn(),
+    useBackendMutation: jest.fn(() => ({ mutate: jest.fn() })),
+}));
+
+const mockDeleteMutation = jest.fn();
+jest.mock('react-query', () => ({
+  ...jest.requireActual('react-query'),
+  useMutation: () => ({
+    mutate: mockDeleteMutation,
+  }),
+}));
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe('SchedulerPage tests', () => {
+    const queryClient = new QueryClient();
+    
+    beforeEach(() => {
+        useBackend.mockImplementation((key, request) => {
+            if (request.url.includes('shift')) {
+                return { data: shiftsMockData };
+            }
+            if (request.url.includes('ride_request')) {
+                return { data: rideRequestsMockData };
+            }
+            if (request.url.includes('driverAvailability')) {
+                return { data: driverAvailabilityMockData };
+            }
+        });
+    });
+
+    const shiftsMockData = [
+        {
+            id: 1,
+            driverID: 1,
+            driverBackupID: 2,
+            day: 'Monday',
+            shiftStart: '02:00PM',
+            shiftEnd: '03:00PM',
+        },
+    ];
+
+    const rideRequestsMockData = [
+        {
+            id: 1,
+            student: 'Alice',
+            day: 'Wednesday',
+            startTime: '12:00PM',
+            endTime: '01:00PM',
+            pickupBuilding: 'Building A',
+            dropoffBuilding: 'Building B',
+        },
+    ];
+
+    const driverAvailabilityMockData = [
+        {
+            id: 1,
+            driverId: 1,
+            day: 'Friday',
+            startTime: '06:00AM',
+            endTime: '07:00AM',
+            notes: 'Available',
+        },
+    ];
+
+    test('renders without crashing', () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter initialEntries={['/admin/schedule/shifts']}>
+                    <Routes>
+                        <Route path="/admin/schedule/:page" element={<SchedulerPage />} />
+                    </Routes>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(screen.getByText('Shifts')).toBeInTheDocument();
+        expect(screen.getByText('Ride Requests')).toBeInTheDocument();
+        expect(screen.getByText('Driver Availability')).toBeInTheDocument();
+    });
+
+    test('navigates to shifts and loads shift events', async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter initialEntries={['/admin/schedule/shifts']}>
+                    <Routes>
+                        <Route path="/admin/schedule/:page" element={<SchedulerPage />} />
+                    </Routes>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Shift for Driver 1')).toBeInTheDocument();
+        });
+    });
+
+    test('navigates to ride requests and loads ride events', async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter initialEntries={['/admin/schedule/rides']}>
+                    <Routes>
+                        <Route path="/admin/schedule/:page" element={<SchedulerPage />} />
+                    </Routes>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Ride Request for Alice')).toBeInTheDocument();
+        });
+    });
+
+    test('navigates to driver availability and loads availability events', async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter initialEntries={['/admin/schedule/driver']}>
+                    <Routes>
+                        <Route path="/admin/schedule/:page" element={<SchedulerPage />} />
+                    </Routes>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Availability for Driver 1')).toBeInTheDocument();
+        });
+    });
+
+    test('action buttons trigger correct callbacks', async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter initialEntries={['/admin/schedule/shifts']}>
+                    <Routes>
+                        <Route path="/admin/schedule/:page" element={<SchedulerPage />} />
+                    </Routes>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Shift for Driver 1')).toBeInTheDocument();
+        });
+
+        const event = screen.getByText('Shift for Driver 1');
+        fireEvent.click(event);
+
+        await waitFor(() => {
+            expect(screen.getByText('Edit')).toBeInTheDocument();
+            expect(screen.getByText('Info')).toBeInTheDocument();
+            expect(screen.getByText('Delete')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByText('Edit'));
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/shift/edit/1'));
+
+        fireEvent.click(screen.getByText('Info'));
+        // expect(window.location.pathname).toBe('/shiftInfo/1');
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/shiftInfo/1'));
+
+        fireEvent.click(screen.getByText('Delete'));
+
+        await waitFor(() => {
+            expect(mockDeleteMutation).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/DriverAvailability.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/DriverAvailability.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.gauchoride.entities;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -21,7 +23,11 @@ public class DriverAvailability {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
   private long driverId;
+
+  @Schema(allowableValues = "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday")
+  @Column(name = "\"day\"")
   private String day;
+  
   private String startTime;
   private String endTime;
   private String notes;

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/Ride.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/Ride.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.gauchoride.entities;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,6 +28,7 @@ public class Ride {
   private String student;
 
   @Schema(allowableValues = "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday")
+  @Column(name = "\"day\"")
   private String day;
   
   private String startTime; // format: HH:MM(A/P)M e.g. "11:00AM" or "1:37PM"

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/Shift.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.GeneratedValue;
@@ -21,6 +22,7 @@ public class Shift {
   private long id;
 
   @Schema(allowableValues = "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday")
+  @Column(name = "\"day\"")
   private String day;
 
   private String shiftStart; // format: HH:MM(A/P)M e.g. "11:00AM" or "01:37PM"


### PR DESCRIPTION
This PR is a proof of concept of the scheduler component, and is a new addition to the existing application

# This PR is dependent on PR #45, for fixing issues that caused the main branch to disfunction.

Deploy link is not available yet, for currently deploying PR #45, and also dokku-13 is out of memory

Closes #33 

### In this PR, I created a `SchedulerEvent`, `SchedulerPanel`, and `SchedulerPage` component that maps data of the following format to a weekly calendar display.

As an admin, people can try out the scheduler component on ride requests, driver availability, and shifts data pulled from the backend. 

The reason why those three data was chosen was because they were recurring event each week.

Also, I wanted to show all forms of data that has the property of `day`, `startTime`, and `endTime` can be put on the scheduler for people to understand. Below is an example event that can be mapped onto the scheduler:

```
{
    title: "Meeting with Team",
    day: "Tuesday",
    startTime: "2:00PM",
    endTime: "4:00PM"
    description: "Going to discuss about what to do in the future"
    actions: [
        {
            text: "Modify",
            variant: "primary",
            callback: modifyFunction()
        },
        {
            text: "Delete",
            variant: "danger",
            callback: deleteFunction()
        }
    ]
}
```

## Scheduler Event

Scheduler event is the most basic component of this PR. It is the block that represents the individual events that gets mapped onto the scheduler.

Its position represents the start of the event and which day it happens on, and its height represents the length of the event.

<img width="289" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/c91d4bb2-7fc8-44ec-a159-bafb09990c3e">

When clicked, the component would show a pop over, showing all the title, time, description, and actions that can be performed.

The reason this extra display exists is because if the duration of any event is small, it would hide the texts because there is no space. Then this pop over would be needed for the user to still see the detailed information.

<img width="414" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/f39f0465-0f7f-4142-8647-873e52f4ca87">

## Scheduler Panel

Scheduler panel is the "table" that contains the grid for hours, days of the week, and where the individual events will map onto. It is also a wrapper for all the scheduler event components.

<img width="1334" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/53a23a4c-3e10-428a-9cfc-1348a8e30a21">

The grid accurately represents the hour and minutes of the event, and can be very helpful for users that are more visually oriented. It is also the whole point of this PR, because looking at a list of entries with day and time is very confusing

### Example:

<img width="1349" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/e65de1b9-667d-49fe-9856-483e8b0490a4">

maps to...

<img width="1255" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/f6311d1c-5ea6-4299-bfad-f04c6a3572ce">

## Scheduler Page

The scheduler page is a wrapper for the scheduler panel component, and it also contains some buttons that can be helpful for developers to see the resulting data display or create new ones.

<img width="1413" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/01c43790-57a3-4661-9c3f-22633af05394">

Currently, the three data available are shifts, driver availability, and ride requests.

### Shifts

Pop over with available actions, for only the admins can view this page

<img width="520" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/c3b43d54-4ba6-4de1-b92a-bc654ad42aa3">

Create new shift button, that navigates to create new shift page

<img width="322" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/673da89b-76b8-4df9-9d51-bf70c8e3d853">

### Driver Availability

Pop over with available actions, for only the admins can view this page

<img width="403" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/0736d974-4976-4676-8831-6b46a1ae4cb9">

Create new driver availability button, that navigates to create new availability page

<img width="299" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/bfe792f3-4f6e-43ee-90cb-1a1aa7696428">

### Ride Requests

Pop over with available actions, for only the admins can view this page

<img width="492" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/13be06cf-ee38-4443-9f29-34d0d661ba9c">

Create new ride request button, that navigates to create new ride request page

<img width="352" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/9e7f7180-1583-49d5-94f5-c4067ba64775">

## On Nav Bar

Currently, the scheduler page is still a proof of concept, so it is deployed and hidden inside the admin dropdown, making it inaccessible to the public.

<img width="1401" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/3a5dc24b-a99b-44e3-8b3b-4f533f6f1c19">

However, if future students of 156 or developers of this application can make use of this work and integrate it into GauchoRide, I believe it can be a great help to the users and administrators that uses this application.

# Ideas for Future developers

- If a event is the same time period with another, and is much shorter, it gets enveloped and cannot be clicked onto anymore, so a width adjusting algorithm can be implemented (see google calendar)
<img width="223" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/b0a1eba3-f5bc-4b09-8012-05979feca040">
<img width="127" alt="image" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-5/assets/36137654/43f9bd55-1ddc-48e1-938f-b4967e400d1e">

- Color of the events are the same right now, which can be confusing and less aesthetically pleasing

Thank you!